### PR TITLE
Added component to exclude specific property extension types

### DIFF
--- a/Source/Core/Runtime/Configuration/ISceneConfiguration.cs
+++ b/Source/Core/Runtime/Configuration/ISceneConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace VRBuilder.Core.Configuration
@@ -11,6 +12,11 @@ namespace VRBuilder.Core.Configuration
         /// Lists all assemblies whose property extensions will be used in the current scene.
         /// </summary>
         IEnumerable<string> ExtensionAssembliesWhitelist { get; }
+
+        /// <summary>
+        /// True if the specified type is not in an exclusion list for the specified assembly.
+        /// </summary>
+        bool IsAllowedInAssembly(Type extensionType, string assemblyName);
 
         /// <summary>
         /// Default resources prefab to use for Confetti behavior.

--- a/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs
+++ b/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs
@@ -30,11 +30,11 @@ namespace VRBuilder.Core.Configuration
                 IEnumerable<string> assemblyQualifiedNames = disallowedExtensionTypeNames.Select(typeName => $"{typeName}, {assemblyFullName}");
                 List<Type> excludedTypes = new List<Type>();
 
-                foreach(string typeName in assemblyQualifiedNames)
+                foreach (string typeName in assemblyQualifiedNames)
                 {
                     Type excludedType = Type.GetType(typeName);
 
-                    if(excludedType == null)
+                    if (excludedType == null)
                     {
                         Debug.LogWarning($"Property extension exclusion list for assembly '{assemblyFullName}' contains invalid extension type: '{typeName}'.");
                     }

--- a/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs
+++ b/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace VRBuilder.Core.Configuration
+{
+    public class PropertyExtensionExclusionList : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Full name of the assembly we want to exclude the types from.")]
+        private string assemblyFullName;
+
+        [SerializeField]
+        [Tooltip("List of excluded extension type names, including namespaces.")]
+        private List<string> disallowedExtensionTypeNames;
+
+        /// <summary>
+        /// Full name of the assembly we want to exclude the types from.
+        /// </summary>
+        public string AssemblyFullName => assemblyFullName;
+
+        /// <summary>
+        /// List of excluded extension types.
+        /// </summary>
+        public IEnumerable<Type> DisallowedExtensionTypes
+        {
+            get
+            {
+                IEnumerable<string> assemblyQualifiedNames = disallowedExtensionTypeNames.Select(typeName => $"{typeName}, {assemblyFullName}");
+                List<Type> excludedTypes = new List<Type>();
+
+                foreach(string typeName in assemblyQualifiedNames)
+                {
+                    Type excludedType = Type.GetType(typeName);
+
+                    if(excludedType == null)
+                    {
+                        Debug.LogWarning($"Property extension exclusion list for assembly '{assemblyFullName}' contains invalid extension type: '{typeName}'.");
+                    }
+                    else
+                    {
+                        excludedTypes.Add(excludedType);
+                    }
+                }
+
+                return excludedTypes;
+            }
+        }
+    }
+}

--- a/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs.meta
+++ b/Source/Core/Runtime/Configuration/PropertyExtensionExclusionList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37f6dae5e7ccf6546ab7d78a5be9d9d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Core/Runtime/Configuration/SceneConfiguration.cs
+++ b/Source/Core/Runtime/Configuration/SceneConfiguration.cs
@@ -29,9 +29,9 @@ namespace VRBuilder.Core.Configuration
         }
 
         /// <inheritdoc/>
-        public bool IsAllowedInAssembly(Type extensionType,  string assemblyName)
+        public bool IsAllowedInAssembly(Type extensionType, string assemblyName)
         {
-            if(ExtensionAssembliesWhitelist.Contains(assemblyName) == false)
+            if (ExtensionAssembliesWhitelist.Contains(assemblyName) == false)
             {
                 return false;
             }
@@ -55,11 +55,11 @@ namespace VRBuilder.Core.Configuration
         {
             foreach (string assemblyName in assemblyNames)
             {
-                if(extensionAssembliesWhitelist.Contains(assemblyName) == false)
+                if (extensionAssembliesWhitelist.Contains(assemblyName) == false)
                 {
                     extensionAssembliesWhitelist.Add(assemblyName);
                 }
             }
-        }        
+        }
     }
 }

--- a/Source/Core/Runtime/Configuration/SceneConfiguration.cs
+++ b/Source/Core/Runtime/Configuration/SceneConfiguration.cs
@@ -1,6 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
-using VRBuilder.Unity;
 
 namespace VRBuilder.Core.Configuration
 {
@@ -17,18 +18,34 @@ namespace VRBuilder.Core.Configuration
         [Tooltip("Default resources prefab to use for the Confetti behavior.")]
         private string defaultConfettiPrefab;
 
-        /// <summary>
-        /// Lists all assemblies whose property extensions will be used in the current scene.
-        /// </summary>
+        /// <inheritdoc/>
         public IEnumerable<string> ExtensionAssembliesWhitelist => extensionAssembliesWhitelist;
 
-        /// <summary>
-        /// Default resources prefab to use for Confetti behavior.
-        /// </summary>
+        /// <inheritdoc/>
         public string DefaultConfettiPrefab
         {
             get { return defaultConfettiPrefab; }
             set { defaultConfettiPrefab = value; }
+        }
+
+        /// <inheritdoc/>
+        public bool IsAllowedInAssembly(Type extensionType,  string assemblyName)
+        {
+            if(ExtensionAssembliesWhitelist.Contains(assemblyName) == false)
+            {
+                return false;
+            }
+
+            PropertyExtensionExclusionList blacklist = GetComponents<PropertyExtensionExclusionList>().FirstOrDefault(blacklist => blacklist.AssemblyFullName == assemblyName);
+
+            if (blacklist == null)
+            {
+                return true;
+            }
+            else
+            {
+                return blacklist.DisallowedExtensionTypes.Any(disallowedType => disallowedType.FullName == extensionType.FullName) == false;
+            }
         }
 
         /// <summary>

--- a/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
@@ -121,7 +121,7 @@ namespace VRBuilder.Core.Properties
             {
                 string assemblyName = concreteExtension.Assembly.FullName;
 
-                if (RuntimeConfigurator.Configuration.SceneConfiguration.ExtensionAssembliesWhitelist.Contains(assemblyName))
+                if (RuntimeConfigurator.Configuration.SceneConfiguration.IsAllowedInAssembly(concreteExtension, assemblyName))
                 {
                     property.SceneObject.GameObject.AddComponent(concreteExtension);
                 }

--- a/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
@@ -3,12 +3,12 @@
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Core.Utils;
-using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace VRBuilder.Core.Properties
@@ -75,7 +75,7 @@ namespace VRBuilder.Core.Properties
                 Type propertyType = ReflectionUtils
                     .GetAllTypes()
                     .Where(processProperty.IsAssignableFrom)
-                    .Where(type => type.Assembly.GetReferencedAssemblies().All(assemblyName =>  assemblyName.Name != "UnityEditor" && assemblyName.Name != "nunit.framework"))
+                    .Where(type => type.Assembly.GetReferencedAssemblies().All(assemblyName => assemblyName.Name != "UnityEditor" && assemblyName.Name != "nunit.framework"))
                     .First(type => type.IsClass && type.IsPublic && type.IsAbstract == false);
 
                 sceneObjectProperty = sceneObject.GameObject.AddComponent(propertyType) as ISceneObjectProperty;
@@ -100,12 +100,11 @@ namespace VRBuilder.Core.Properties
                 .Where(type => type.Assembly.GetReferencedAssemblies().All(assemblyName => assemblyName.Name != "UnityEditor" && assemblyName.Name != "nunit.framework"))
                 .Where(type => type.IsPublic && type.IsPointer == false && type.IsByRef == false).ToList();
 
-
             List<Type> extensionTypes = new List<Type>();
 
-            foreach (Type type in propertyTypes) 
+            foreach (Type type in propertyTypes)
             {
-                if(typeof(ISceneObjectProperty).IsAssignableFrom(type))
+                if (typeof(ISceneObjectProperty).IsAssignableFrom(type))
                 {
                     extensionTypes.Add(typeof(ISceneObjectPropertyExtension<>).MakeGenericType(type));
                 }
@@ -115,9 +114,9 @@ namespace VRBuilder.Core.Properties
                 .GetAllTypes()
                 .Where(type => extensionTypes.Any(extensionType => extensionType.IsAssignableFrom(type)))
                 .Where(type => type.Assembly.GetReferencedAssemblies().All(assemblyName => assemblyName.Name != "UnityEditor" && assemblyName.Name != "nunit.framework"))
-                .Where(type => type.IsClass && type.IsPublic && type.IsAbstract == false).ToList();           
+                .Where(type => type.IsClass && type.IsPublic && type.IsAbstract == false).ToList();
 
-            foreach(Type concreteExtension in availableExtensions)
+            foreach (Type concreteExtension in availableExtensions)
             {
                 string assemblyName = concreteExtension.Assembly.FullName;
 


### PR DESCRIPTION
Added component to exclude specific property extension types when automatically adding property extensions.

A number of `PropertyExtensionExclusionList` components can be added to the `PROCESS_CONFIGURATION` game object.
Each component can list scene property extension belonging to a specific assembly that will not be automatically added to gameobjects, even if the assembly is whitelisted in the `SceneConfiguration` component.

The fields on the component are:
- The assembly's full name.
- A list of type names to be excluded. Type names should include namespaces.