### PR TITLE
Added Teleportation Anchor Proximity Detection

### DIFF
--- a/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderAnchorPrefab.prefab
+++ b/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderAnchorPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5596475480445098980}
   - component: {fileID: 5242423274253954953}
   - component: {fileID: 6409087973028353356}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Cylinder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,12 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4068937989341869999}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5733726700563844070}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &5242423274253954953
 MeshFilter:
@@ -51,10 +52,12 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -79,6 +82,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &7300814356168881535
 GameObject:
   m_ObjectHideFlags: 0
@@ -90,7 +94,7 @@ GameObject:
   - component: {fileID: 5733726700563844070}
   - component: {fileID: 2853389822534241342}
   - component: {fileID: 5852872955982643672}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Plane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -104,13 +108,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7300814356168881535}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5596475480445098980}
   m_Father: {fileID: 6464055494847607605}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!33 &2853389822534241342
 MeshFilter:
@@ -131,10 +136,12 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -159,6 +166,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8320129621220576684
 GameObject:
   m_ObjectHideFlags: 0
@@ -168,7 +176,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6464055494847607605}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VRBuilderAnchorPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -182,11 +190,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8320129621220576684}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5733726700563844070}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab
+++ b/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3298320452103383601
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6957521850329521647}
+  - component: {fileID: 2830758243183112165}
+  - component: {fileID: 6432292129705344766}
+  - component: {fileID: 6590237481188370846}
+  m_Layer: 0
+  m_Name: VRBuilderTeleportationAnchorProximityEntryPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6957521850329521647
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3298320452103383601}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2830758243183112165
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3298320452103383601}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6432292129705344766
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3298320452103383601}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &6590237481188370846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3298320452103383601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95106524e2323f64187dd585468c028a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab
+++ b/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab
@@ -53,7 +53,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 1, y: 0.5, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &6432292129705344766
 Rigidbody:

--- a/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab.meta
+++ b/Source/Basic-Interaction-Component/Runtime/Resources/VRBuilderTeleportationAnchorProximityEntryPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 964fd9b427d2ce946b252a940347f5aa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Core/Runtime/Utils/GameObjectExtension.cs
+++ b/Source/Core/Runtime/Utils/GameObjectExtension.cs
@@ -16,7 +16,7 @@ namespace VRBuilder.Core.Utils
             gameObject.layer = layer;
             if (includeChildren == false) return;
 
-            var childs = gameObject.GetComponentsInChildren<T>(true);
+            T[] children = gameObject.GetComponentsInChildren<T>(true);
             for (int i = 0; i < childs.Length; i++)
                 childs[i].gameObject.layer = layer;
         }

--- a/Source/Core/Runtime/Utils/GameObjectExtension.cs
+++ b/Source/Core/Runtime/Utils/GameObjectExtension.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+namespace VRBuilder.Core.Utils
+{
+    public static class GameObjectExtension
+    {
+        /// <summary>
+        /// Set layer of GameObject and children.
+        /// For more efficiency Generic by <Component> is used. In case for specific Component GetComponentsInChildren executes faster, then Transform by default.
+        /// </summary>
+        /// <param name="gameObject">GameObject</param>
+        /// <param name="layer">layer num.</param>
+        /// <param name="includeChildren">Toggle set for children</param>
+        public static void SetLayer<T>(this GameObject gameObject, int layer, bool includeChildren = false) where T : Component
+        {
+            gameObject.layer = layer;
+            if (includeChildren == false) return;
+
+            var childs = gameObject.GetComponentsInChildren<T>(true);
+            for (int i = 0; i < childs.Length; i++)
+                childs[i].gameObject.layer = layer;
+        }
+
+        /// <summary>
+        /// Removes a gameobject child with a specific name.
+        /// As it uses DestroyImmediate it should only be used during editor time.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="name of child to remove"></param>
+        public static void RemoveChildWithNameImmediate(this GameObject gameObject, string name)
+        {
+            for (int i = 0; i < gameObject.transform.childCount; i++)
+            {
+                Transform child = gameObject.transform.GetChild(i);
+                if (child.name == name)
+                {
+                    Object.DestroyImmediate(child.gameObject);
+                    i--;
+                }
+            }
+        }
+    }
+}

--- a/Source/Core/Runtime/Utils/GameObjectExtension.cs
+++ b/Source/Core/Runtime/Utils/GameObjectExtension.cs
@@ -17,8 +17,8 @@ namespace VRBuilder.Core.Utils
             if (includeChildren == false) return;
 
             T[] children = gameObject.GetComponentsInChildren<T>(true);
-            for (int i = 0; i < childs.Length; i++)
-                childs[i].gameObject.layer = layer;
+            for (int i = 0; i < children.Length; i++)
+                children[i].gameObject.layer = layer;
         }
 
         /// <summary>

--- a/Source/Core/Runtime/Utils/GameObjectExtension.cs.meta
+++ b/Source/Core/Runtime/Utils/GameObjectExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6495554f51453c429ef9fb688d11ac0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit;
+using VRBuilder.Core.Properties;
+
+namespace VRBuilder.XRInteraction
+{
+    public class TeleportationAnchorProximityEntry : MonoBehaviour
+    {
+        private TeleportationAnchor teleportationAnchor;
+
+        private void Start()
+        {
+            teleportationAnchor = GetComponentInParent<TeleportationAnchor>();
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!teleportationAnchor.enabled)
+                return;
+
+            Transform objectRoot = other.transform.root;
+            UserSceneObject userSceneObject = objectRoot.GetComponentInChildren<UserSceneObject>();
+            if (userSceneObject != null)
+            {
+                teleportationAnchor.teleporting.Invoke(new TeleportingEventArgs());
+            }
+        }
+    }
+}

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
@@ -4,6 +4,11 @@ using VRBuilder.Core.Properties;
 
 namespace VRBuilder.XRInteraction
 {
+    /// <summary>
+    /// This adds the possibility to move the user into a <seealso cref="TeleportationAnchor"/> and trigger the teleport event without teleporting.
+    /// It will initiate the next step in the VR-Builder process.
+    /// It will not change the users position or rotation set in the <seealso cref="TeleportationAnchor"/>.
+    /// </summary>
     public class TeleportationAnchorProximityEntry : MonoBehaviour
     {
         private TeleportationAnchor teleportationAnchor;

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs
@@ -6,7 +6,6 @@ namespace VRBuilder.XRInteraction
 {
     /// <summary>
     /// This adds the possibility to move the user into a <seealso cref="TeleportationAnchor"/> and trigger the teleport event without teleporting.
-    /// It will initiate the next step in the VR-Builder process.
     /// It will not change the users position or rotation set in the <seealso cref="TeleportationAnchor"/>.
     /// </summary>
     public class TeleportationAnchorProximityEntry : MonoBehaviour

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs.meta
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorProximityEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95106524e2323f64187dd585468c028a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorVRBuilder.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorVRBuilder.cs
@@ -13,6 +13,7 @@ namespace VRBuilder.XRInteraction
         /// <inheritdoc />
         protected override void OnSelectEntered(SelectEnterEventArgs args)
         {
+            Debug.Log("OnSelectEntered Awake");
             CheckTeleportationProvider(args.interactorObject);
 
             base.OnSelectEntered(args);
@@ -21,6 +22,7 @@ namespace VRBuilder.XRInteraction
         /// <inheritdoc />
         protected override void OnSelectExited(SelectExitEventArgs args)
         {
+            Debug.Log("OnSelectExited Awake");
             CheckTeleportationProvider(args.interactorObject);
 
             base.OnSelectExited(args);

--- a/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorVRBuilder.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Interaction/Interactables/TeleportationAnchorVRBuilder.cs
@@ -13,7 +13,6 @@ namespace VRBuilder.XRInteraction
         /// <inheritdoc />
         protected override void OnSelectEntered(SelectEnterEventArgs args)
         {
-            Debug.Log("OnSelectEntered Awake");
             CheckTeleportationProvider(args.interactorObject);
 
             base.OnSelectEntered(args);
@@ -22,7 +21,6 @@ namespace VRBuilder.XRInteraction
         /// <inheritdoc />
         protected override void OnSelectExited(SelectExitEventArgs args)
         {
-            Debug.Log("OnSelectExited Awake");
             CheckTeleportationProvider(args.interactorObject);
 
             base.OnSelectExited(args);


### PR DESCRIPTION
- Proximity Detection for anchor can be added via button on TeleportationAnchorVRBuilder
- Added new extensions SetLayer, RemoveChildWithNameImmediate
- When adding the DefaultTeleportationAnchor or Proximity Detection old Version is removed (I feel this is the better behavior as the collider is also always modified)
- When adding the DefaultTeleportationAnchor it is added as teleportAnchorTransform on the TeleportationAnchor
- The prefabs VRBuilderAnchorPrefab and VRBuilderTeleportationAnchorProximityEntryPrefab have now default layer and will get the layer of the parent TeleportationAnchor

Note: I did not expected that ConfigureVRBuilderDefaults will be run on ConfigureDefaultTeleportationAnchor but I did not change this because it might be expected behavior for existing users.