### PR TITLE
Feature: animationcurves enhancements

### DIFF
--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
@@ -51,6 +51,10 @@ namespace VRBuilder.Core.Behaviors
             [DisplayName("Animation (in seconds)")]
             public float Duration { get; set; }
 
+            [DataMember]
+            [DisplayName("Animation curve")]
+            public AnimationCurve AnimationCurve = AnimationCurve.Linear(0, 0, 1, 1);
+
             /// <inheritdoc />
             public Metadata Metadata { get; set; }
 
@@ -113,8 +117,8 @@ namespace VRBuilder.Core.Behaviors
 
                     float progress = (Time.time - startingTime) / Data.Duration;
 
-                    movingTransform.position = Vector3.Lerp(initialPosition, targetPositionTransform.position, progress);
-                    movingTransform.rotation = Quaternion.Slerp(initialRotation, targetPositionTransform.rotation, progress);
+                    movingTransform.position = initialPosition + (targetPositionTransform.position - initialPosition) * Data.AnimationCurve.Evaluate(progress);
+                    movingTransform.rotation = Quaternion.Euler(initialRotation.eulerAngles + (targetPositionTransform.rotation.eulerAngles - initialRotation.eulerAngles) * Data.AnimationCurve.Evaluate(progress));
 
                     yield return null;
                 }

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ScalingBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ScalingBehavior.cs
@@ -27,13 +27,17 @@ namespace VRBuilder.Core.Behaviors
             public Vector3 TargetScale { get; set; }
 
             // Duration of the animation in seconds.
-#if CREATOR_PRO     
+#if CREATOR_PRO
             [OptionalValue]
 #endif
             [DataMember]
             [DisplayName("Animation Duration (in seconds)")]
             public float Duration { get; set; }
 
+            [DataMember]
+            [DisplayName("Animation curve")]
+            public AnimationCurve AnimationCurve = AnimationCurve.Linear(0, 0, 1, 1);
+    
             public Metadata Metadata { get; set; }
 
             /// <inheritdoc />
@@ -65,7 +69,7 @@ namespace VRBuilder.Core.Behaviors
             public ActivatingProcess(EntityData data) : base(data)
             {
             }
-            
+
             /// <inheritdoc />
             public override void Start()
             {
@@ -85,7 +89,7 @@ namespace VRBuilder.Core.Behaviors
                     RuntimeConfigurator.Configuration.SceneObjectManager.RequestAuthority(Data.Target.Value);
 
                     float progress = (Time.time - startedAt) / Data.Duration;
-                    scaledTransform.localScale = Vector3.Lerp(initialScale, Data.TargetScale, progress);
+                    scaledTransform.localScale = initialScale + (Data.TargetScale - initialScale) * Data.AnimationCurve.Evaluate(progress);
                     yield return null;
                 }
             }
@@ -104,7 +108,7 @@ namespace VRBuilder.Core.Behaviors
             {
             }
         }
-        
+
         /// <inheritdoc />
         public override IStageProcess GetActivatingProcess()
         {


### PR DESCRIPTION
I added Animation Curves to Scale and Move Object, which also enabled cartoonesque wobbly effects with curves with curves greater 1, which isn't possible with lerp. Example can be seen below.

![image](https://github.com/MindPort-GmbH/VR-Builder/assets/601797/28d008da-1152-42fa-9f2f-1c36dbbeb3f3)

https://github.com/MindPort-GmbH/VR-Builder/assets/601797/72a448dd-31c9-4a81-ad00-adba63dc104c

It is backward compatible as I used "AnimationCurve.Linear"

As always feel free to customize before merging.