### PR TITLE
Feature/mp 2125 remove the unique name on process scene objects

### DIFF
--- a/Demo/Runtime/Scenes/VR Builder Demo - Core Features.unity
+++ b/Demo/Runtime/Scenes/VR Builder Demo - Core Features.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.023795161, g: 0.0029395288, b: 0.05422297, a: 1}
+  m_IndirectSpecularColor: {r: 0.02383257, g: 0.0029243836, b: 0.05424137, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -104,7 +104,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +117,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -146,13 +146,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3859426}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.017132446, y: 0.023738552, z: -0.011670226, w: 0.9995033}
   m_LocalPosition: {x: -0.027674861, y: -0.00000018596648, z: 0.00000015173107}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1974977439}
   m_Father: {fileID: 1685999355}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &24327721
 GameObject:
@@ -177,13 +178,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 24327721}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.037149172, y: -0.0391672, z: -0.020477412, w: 0.9983319}
   m_LocalPosition: {x: -0.062340543, y: -0.00000025370625, z: -0.00000015303492}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1230062442}
   m_Father: {fileID: 1584070614}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &33704421
 GameObject:
@@ -208,9 +210,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 33704421}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 1.5, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 221845637}
   - {fileID: 1525491574}
@@ -218,13 +222,13 @@ Transform:
   - {fileID: 861048855}
   - {fileID: 518602151}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1001 &53683353
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 248065651}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 1ed1d5cc1197f8144a46c56a59341db7, type: 3}
@@ -296,6 +300,15 @@ PrefabInstance:
       value: MagicCube
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 1ed1d5cc1197f8144a46c56a59341db7, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 53683356}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 1ed1d5cc1197f8144a46c56a59341db7, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 53683357}
   m_SourcePrefab: {fileID: 100100000, guid: 1ed1d5cc1197f8144a46c56a59341db7, type: 3}
 --- !u!4 &53683354 stripped
 Transform:
@@ -315,9 +328,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 53683355}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.39999995, y: 0.39999995, z: 0.39999995}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &53683357
@@ -333,6 +354,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Cube
+  guid: 78d0863c-3206-4e9c-9052-e7878b2ae5ad
   tags: []
 --- !u!1 &72067213
 GameObject:
@@ -361,13 +383,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 72067213}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2096665701}
   m_Father: {fileID: 1719448854}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &72067215
 MonoBehaviour:
@@ -384,6 +407,11 @@ MonoBehaviour:
   m_LineWidth: 0.02
   m_OverrideInteractorLineLength: 1
   m_LineLength: 10
+  m_AutoAdjustLineLength: 0
+  m_MinLineLength: 0.5
+  m_UseDistanceToHitAsMaxLineLength: 1
+  m_LineRetractionDelay: 0.5
+  m_LineLengthChangeSpeed: 12
   m_WidthCurve:
     serializedVersion: 2
     m_Curve:
@@ -408,6 +436,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  m_SetLineColorGradient: 1
   m_ValidColorGradient:
     serializedVersion: 2
     key0: {r: 0.47058824, g: 0.94509804, b: 0.78431374, a: 0}
@@ -435,6 +464,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_InvalidColorGradient:
@@ -464,6 +494,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_BlockedColorGradient:
@@ -493,6 +524,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 2
     m_NumAlphaKeys: 2
   m_TreatSelectionAsValidState: 0
@@ -504,8 +536,13 @@ MonoBehaviour:
   m_StopLineAtFirstRaycastHit: 1
   m_StopLineAtSelection: 0
   m_SnapEndpointIfAvailable: 1
+  m_LineBendRatio: 0.5
+  m_OverrideInteractorLineOrigin: 1
+  m_LineOriginTransform: {fileID: 0}
+  m_LineOriginOffset: 0
 --- !u!120 &72067216
 LineRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -515,6 +552,7 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -604,16 +642,20 @@ LineRenderer:
       atime6: 0
       atime7: 0
       m_Mode: 0
+      m_ColorSpace: -1
       m_NumColorKeys: 2
       m_NumAlphaKeys: 2
     numCornerVertices: 4
     numCapVertices: 4
     alignment: 0
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     shadowBias: 0
     generateLightingData: 0
+  m_MaskInteraction: 0
   m_UseWorldSpace: 1
   m_Loop: 0
+  m_ApplyActiveColorSpace: 0
 --- !u!114 &72067217
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -732,6 +774,15 @@ MonoBehaviour:
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
   m_AnchorRotationMode: 0
+  m_UIHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_UIHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_EnableARRaycasting: 0
+  m_OccludeARHitsWith3DObjects: 0
+  m_OccludeARHitsWith2DObjects: 0
 --- !u!114 &72067218
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -777,6 +828,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 8248158260566104461, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: c156df21-389e-4da4-9254-8e183001fa35
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -856,6 +919,18 @@ MonoBehaviour:
       m_Type: 0
       m_ExpectedControlType: 
       m_Id: 4936da6e-2314-466c-ac19-aa23d9db394b
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: 1c372ed1-f11c-4703-a226-edd8fb48db0a
       m_Processors: 
       m_Interactions: 
       m_SingletonActionBindings: []
@@ -948,6 +1023,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Sliced Cube (2)
+  guid: a0970d31-1fbf-40e5-8c8f-6bb4ba81f164
   tags: []
 --- !u!114 &102893244
 MonoBehaviour:
@@ -1028,6 +1104,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -1058,6 +1135,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -1152,10 +1241,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 102893242}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -1169,9 +1269,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 102893242}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.40000013, y: 0.39999995, z: 0.20000006}
   m_Center: {x: 0, y: 0, z: -0.10000027}
 --- !u!23 &102893250
@@ -1185,6 +1293,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1231,12 +1340,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 102893242}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0.01, y: 1.2, z: 0.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1756511964}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &110401192
 GameObject:
@@ -1265,13 +1375,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 110401192}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 941988691}
   m_Father: {fileID: 1847977965}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &110401194
 MonoBehaviour:
@@ -1288,6 +1399,11 @@ MonoBehaviour:
   m_LineWidth: 0.02
   m_OverrideInteractorLineLength: 1
   m_LineLength: 10
+  m_AutoAdjustLineLength: 0
+  m_MinLineLength: 0.5
+  m_UseDistanceToHitAsMaxLineLength: 1
+  m_LineRetractionDelay: 0.5
+  m_LineLengthChangeSpeed: 12
   m_WidthCurve:
     serializedVersion: 2
     m_Curve:
@@ -1312,6 +1428,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  m_SetLineColorGradient: 1
   m_ValidColorGradient:
     serializedVersion: 2
     key0: {r: 0.47058824, g: 0.94509804, b: 0.78431374, a: 0}
@@ -1339,6 +1456,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_InvalidColorGradient:
@@ -1368,6 +1486,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_BlockedColorGradient:
@@ -1397,6 +1516,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 2
     m_NumAlphaKeys: 2
   m_TreatSelectionAsValidState: 0
@@ -1408,8 +1528,13 @@ MonoBehaviour:
   m_StopLineAtFirstRaycastHit: 1
   m_StopLineAtSelection: 0
   m_SnapEndpointIfAvailable: 1
+  m_LineBendRatio: 0.5
+  m_OverrideInteractorLineOrigin: 1
+  m_LineOriginTransform: {fileID: 0}
+  m_LineOriginOffset: 0
 --- !u!120 &110401195
 LineRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1419,6 +1544,7 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -1505,16 +1631,20 @@ LineRenderer:
       atime6: 0
       atime7: 0
       m_Mode: 0
+      m_ColorSpace: -1
       m_NumColorKeys: 2
       m_NumAlphaKeys: 2
     numCornerVertices: 4
     numCapVertices: 4
     alignment: 0
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     shadowBias: 0.5
     generateLightingData: 0
+  m_MaskInteraction: 0
   m_UseWorldSpace: 1
   m_Loop: 0
+  m_ApplyActiveColorSpace: 0
 --- !u!114 &110401196
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1633,6 +1763,15 @@ MonoBehaviour:
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
   m_AnchorRotationMode: 0
+  m_UIHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_UIHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_EnableARRaycasting: 0
+  m_OccludeARHitsWith3DObjects: 0
+  m_OccludeARHitsWith2DObjects: 0
 --- !u!114 &110401197
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1678,6 +1817,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 5101698808175986029, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: 2490de64-0e92-4c84-9c31-5fec5b0e1209
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -1762,6 +1913,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: eb549828-420c-4ee7-917f-924e70f1f2c4
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_HapticDeviceAction:
     m_UseReference: 1
     m_Action:
@@ -1834,13 +1997,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 119691935}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.0013731687, y: -0.0005792431, z: -0.08538537, w: 0.9963469}
   m_LocalPosition: {x: -0.028493328, y: -0.00000044822693, z: -0.0000003170967}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1634327993}
   m_Father: {fileID: 1899651030}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &130388567
 GameObject:
@@ -1865,13 +2029,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 130388567}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.006532279, y: 0.0032989993, z: -0.17059992, w: 0.98531324}
   m_LocalPosition: {x: -0.023907261, y: -0.00000026226044, z: 0.00000022888183}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 906347380}
   m_Father: {fileID: 1812729733}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &134998303
 GameObject:
@@ -1898,12 +2063,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 134998303}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1222594156}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &134998305
 MeshRenderer:
@@ -1916,6 +2082,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1977,12 +2144,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 154673131}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000022351742, y: 0.000000014901163, z: -0.00000002793968, w: 1}
   m_LocalPosition: {x: -0.017860297, y: 0.00000007152557, z: -0.00000015258789}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1155200664}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &162167681
 GameObject:
@@ -2007,13 +2175,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 162167681}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99872494, y: -0.046419356, z: -0.015558949, w: -0.012318821}
   m_LocalPosition: {x: -0.05391815, y: 0.0050031445, z: 0.0017454529}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 197306239}
   m_Father: {fileID: 236400690}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &173879117
 GameObject:
@@ -2038,12 +2207,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 173879117}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000022351742, y: 0.000000014901163, z: -0.00000002793968, w: 1}
   m_LocalPosition: {x: -0.017860297, y: 0.00000007152557, z: -0.00000015258789}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 702952330}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &182423183
 GameObject:
@@ -2068,13 +2238,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 182423183}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.018601296, y: 0.022547437, z: -0.058639184, w: 0.99785125}
   m_LocalPosition: {x: -0.056403197, y: -0.00000059507784, z: 0.0000003004074}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 277694094}
   m_Father: {fileID: 1172561681}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &185363457
 GameObject:
@@ -2104,12 +2275,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 185363457}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.01, y: 0.4, z: 0.4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 248065651}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &185363459
 MonoBehaviour:
@@ -2136,6 +2308,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Slicing highlight
+  guid: 91fa53b9-8b4a-49f2-bcff-2267fed31898
   tags: []
 --- !u!65 &185363461
 BoxCollider:
@@ -2145,9 +2318,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 185363457}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 2, y: 1, z: 1.5}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &185363462
@@ -2161,6 +2342,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2222,13 +2404,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 197306238}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.037149172, y: -0.0391672, z: -0.020477412, w: 0.9983319}
   m_LocalPosition: {x: -0.062340543, y: -0.00000025370625, z: -0.00000015303492}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 393208952}
   m_Father: {fileID: 162167682}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &203271640
 GameObject:
@@ -2253,12 +2436,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 203271640}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.36650118, y: 0, z: 0, w: 0.9304176}
   m_LocalPosition: {x: 0.0447, y: -0.0476, z: 0.0131}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 673255607}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 43, y: 0, z: 0}
 --- !u!1 &221845636
 GameObject:
@@ -2288,13 +2472,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 221845636}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0.4, z: 1.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1745294527}
   m_Father: {fileID: 33704422}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!114 &221845638
 MonoBehaviour:
@@ -2365,9 +2550,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 221845636}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.4, y: 0.4, z: 0.2}
   m_Center: {x: 0, y: 0, z: -0.1}
 --- !u!114 &221845640
@@ -2418,6 +2611,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Sliced Cube (1)_SnapZone
+  guid: 2a2d1ad0-f95d-4b40-b74e-f08abac3b501
   tags: []
 --- !u!1 &224249723
 GameObject:
@@ -2442,13 +2636,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 224249723}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.018601296, y: 0.022547437, z: -0.058639184, w: 0.99785125}
   m_LocalPosition: {x: -0.056403197, y: -0.00000059507784, z: 0.0000003004074}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 253252368}
   m_Father: {fileID: 1573805702}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &232339299
 GameObject:
@@ -2477,13 +2672,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 232339299}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1268751234}
   m_Father: {fileID: 1756511964}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &232339301
 MonoBehaviour:
@@ -2512,9 +2708,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 232339299}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 0.01, z: 1}
   m_Center: {x: 0, y: 0.02, z: 0}
 --- !u!114 &232339303
@@ -2538,6 +2742,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -2568,6 +2773,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -2629,6 +2846,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Teleportation Spot_1
+  guid: 1a312f7e-b8b2-4773-a3f3-26a759072809
   tags: []
 --- !u!1 &236400689
 GameObject:
@@ -2653,9 +2871,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 236400689}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: -1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 386644692}
   - {fileID: 1172561681}
@@ -2663,7 +2883,6 @@ Transform:
   - {fileID: 1293420566}
   - {fileID: 692521587}
   m_Father: {fileID: 621906708}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &242342981
 GameObject:
@@ -2691,12 +2910,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 242342981}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 503181885}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &242342983
 MeshRenderer:
@@ -2709,6 +2929,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2789,15 +3010,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 248065650}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3, y: 1.2, z: 5.25}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 185363458}
   - {fileID: 53683354}
   - {fileID: 561255720}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &248065653
 MonoBehaviour:
@@ -2878,6 +3100,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -2908,6 +3131,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -3002,10 +3237,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 248065650}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -3024,6 +3270,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Magic Cube
+  guid: 91ce897d-0ae3-4bbf-a0cd-4474ce2c2764
   tags: []
 --- !u!1 &253252367
 GameObject:
@@ -3048,13 +3295,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 253252367}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0012706812, y: -0.0023152584, z: -0.06524572, w: 0.99786574}
   m_LocalPosition: {x: -0.033131722, y: 0.00000038266182, z: -0.00000061273573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1155200664}
   m_Father: {fileID: 224249724}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &277694093
 GameObject:
@@ -3079,19 +3327,21 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 277694093}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0012706812, y: -0.0023152584, z: -0.06524572, w: 0.99786574}
   m_LocalPosition: {x: -0.033131722, y: 0.00000038266182, z: -0.00000061273573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 702952330}
   m_Father: {fileID: 182423184}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &286338418
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 1abcf478131f05645a9e8efbebd736db, type: 3}
@@ -3171,12 +3421,16 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1abcf478131f05645a9e8efbebd736db, type: 3}
 --- !u!1001 &308985786
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 2432b9d584ff8c44c88073c39743e60b, type: 3}
@@ -3268,6 +3522,9 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2432b9d584ff8c44c88073c39743e60b, type: 3}
 --- !u!1 &313596991
 GameObject:
@@ -3292,13 +3549,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 313596991}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99804187, y: -0.04426889, z: 0.04315787, w: 0.009497783}
   m_LocalPosition: {x: -0.05238823, y: 0.0045133065, z: -0.011750946}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1116639954}
   m_Father: {fileID: 1880869866}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &325914044
 GameObject:
@@ -3325,12 +3583,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 325914044}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2015042050}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &325914046
 MonoBehaviour:
@@ -3344,11 +3603,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ab68ce6587aab0146b8dabefbd806791, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_ClickSpeed: 0.3
   m_MoveDeadzone: 0.6
   m_RepeatDelay: 0.5
   m_RepeatRate: 0.1
   m_TrackedDeviceDragThresholdMultiplier: 2
+  m_TrackedScrollDeltaMultiplier: 5
   m_ActiveInputMode: 0
   m_MaxTrackedDeviceRaycastDistance: 1000
   m_EnableXRInput: 1
@@ -3389,6 +3650,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 813701130}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
@@ -3460,6 +3722,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2100000, guid: abb9f2a27e7f7184b881acce31145657, type: 2}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1831340544}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 535653421}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2121825125}
   m_SourcePrefab: {fileID: 100100000, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
 --- !u!1 &375530499
 GameObject:
@@ -3486,13 +3760,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 375530499}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 655638806}
   m_Father: {fileID: 1883760419}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &375530501
 MeshRenderer:
@@ -3505,6 +3780,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -3566,13 +3842,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 386644691}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.9956038, y: -0.056100972, z: -0.070293866, w: -0.026165245}
   m_LocalPosition: {x: -0.05402496, y: 0.0060563944, z: 0.02002304}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 813252711}
   m_Father: {fileID: 236400690}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &393208951
 GameObject:
@@ -3597,13 +3874,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 393208951}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0013464622, y: -0.0029157132, z: -0.22192244, w: 0.9750591}
   m_LocalPosition: {x: -0.039041024, y: 0.0000006005168, z: 0.00000011503696}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1339959895}
   m_Father: {fileID: 197306239}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &408361953
 GameObject:
@@ -3632,13 +3910,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 408361953}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 622743096}
   m_Father: {fileID: 1719448854}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &408361955
 MonoBehaviour:
@@ -3655,6 +3934,11 @@ MonoBehaviour:
   m_LineWidth: 0.02
   m_OverrideInteractorLineLength: 1
   m_LineLength: 10
+  m_AutoAdjustLineLength: 0
+  m_MinLineLength: 0.5
+  m_UseDistanceToHitAsMaxLineLength: 1
+  m_LineRetractionDelay: 0.5
+  m_LineLengthChangeSpeed: 12
   m_WidthCurve:
     serializedVersion: 2
     m_Curve:
@@ -3679,6 +3963,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  m_SetLineColorGradient: 1
   m_ValidColorGradient:
     serializedVersion: 2
     key0: {r: 0.47058824, g: 0.94509804, b: 0.78431374, a: 0}
@@ -3706,6 +3991,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_InvalidColorGradient:
@@ -3735,6 +4021,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_BlockedColorGradient:
@@ -3764,6 +4051,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 2
     m_NumAlphaKeys: 2
   m_TreatSelectionAsValidState: 0
@@ -3775,8 +4063,13 @@ MonoBehaviour:
   m_StopLineAtFirstRaycastHit: 1
   m_StopLineAtSelection: 0
   m_SnapEndpointIfAvailable: 1
+  m_LineBendRatio: 0.5
+  m_OverrideInteractorLineOrigin: 1
+  m_LineOriginTransform: {fileID: 0}
+  m_LineOriginOffset: 0
 --- !u!120 &408361956
 LineRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -3786,6 +4079,7 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -3870,16 +4164,20 @@ LineRenderer:
       atime6: 0
       atime7: 0
       m_Mode: 0
+      m_ColorSpace: -1
       m_NumColorKeys: 2
       m_NumAlphaKeys: 2
     numCornerVertices: 4
     numCapVertices: 4
     alignment: 0
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     shadowBias: 0.5
     generateLightingData: 0
+  m_MaskInteraction: 0
   m_UseWorldSpace: 1
   m_Loop: 0
+  m_ApplyActiveColorSpace: 0
 --- !u!114 &408361957
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3998,6 +4296,15 @@ MonoBehaviour:
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
   m_AnchorRotationMode: 0
+  m_UIHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_UIHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_EnableARRaycasting: 0
+  m_OccludeARHitsWith3DObjects: 0
+  m_OccludeARHitsWith2DObjects: 0
 --- !u!114 &408361958
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4043,6 +4350,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 8248158260566104461, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: d604ffb3-d04c-4096-a8e2-ac96e9421761
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -4127,6 +4446,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: ee7c7a6d-bf3c-427e-a679-2e29dc800493
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_HapticDeviceAction:
     m_UseReference: 1
     m_Action:
@@ -4204,13 +4535,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 503181884}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.2, z: 0.7500001}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 242342982}
   m_Father: {fileID: 1756511964}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &503181886
 MonoBehaviour:
@@ -4281,9 +4613,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 503181884}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.4, y: 0.4, z: 0.4}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &503181888
@@ -4333,6 +4673,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Magic Cube_SnapZone_1
+  guid: cc3bee43-1697-4d3c-adde-8b4f38e20834
   tags: []
 --- !u!1 &518602150
 GameObject:
@@ -4360,12 +4701,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 518602150}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 1.5, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33704422}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &518602152
 MonoBehaviour:
@@ -4380,6 +4722,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Teleportation area
+  guid: a65c9a03-0238-44f4-bead-2f467157d38f
   tags: []
 --- !u!114 &518602153
 MonoBehaviour:
@@ -4402,6 +4745,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -4432,6 +4776,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -4487,9 +4843,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 518602150}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -8378139086155444565, guid: 3d993d7375e6eec4d971b7d72f65da14, type: 3}
@@ -4518,15 +4882,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 520054712}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.27542365, y: 0.27542365, z: 0.65126175, w: 0.65126175}
   m_LocalPosition: {x: -0.0358, y: 0.0577, z: -0.1296}
   m_LocalScale: {x: 0.95, y: 0.95, z: 0.95}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1880869866}
   - {fileID: 1999009289}
   - {fileID: 1783782960}
   m_Father: {fileID: 873635844}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -45.848, y: 0, z: 90}
 --- !u!114 &520054714
 MonoBehaviour:
@@ -4576,7 +4941,7 @@ Mesh:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 10
+  serializedVersion: 11
   m_SubMeshes:
   - serializedVersion: 2
     firstByte: 0
@@ -4723,6 +5088,7 @@ Mesh:
     m_Center: {x: -0.000000029802322, y: 0.000000029802322, z: 0.000000007450581}
     m_Extent: {x: 0.2, y: 0.2, z: 0.19999999}
   m_MeshUsageFlags: 0
+  m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshMetrics[0]: 1.8829471
@@ -4756,14 +5122,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 533398622}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.9956038, y: -0.056100972, z: -0.070293866, w: -0.026165245}
   m_LocalPosition: {x: -0.05402496, y: 0.0060563944, z: 0.02002304}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1794048751}
   m_Father: {fileID: 1880869866}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &535653421 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+  m_PrefabInstance: {fileID: 1785665711}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &535679136
 GameObject:
   m_ObjectHideFlags: 0
@@ -4788,13 +5160,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 535679136}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1507460097}
   m_Father: {fileID: 1192304054}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &535679138
 MonoBehaviour:
@@ -4809,23 +5182,30 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TransformerEnabled
+  guid: 9e82b970-e0e5-446f-8e96-5d657d8212cf
   tags: []
 --- !u!21 &539108941
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Standard
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _ALPHABLEND_ON
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -4865,6 +5245,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5
@@ -4879,7 +5260,7 @@ Material:
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 5
+    - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
@@ -4909,19 +5290,21 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 548424073}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.006532279, y: 0.0032989993, z: -0.17059992, w: 0.98531324}
   m_LocalPosition: {x: -0.023907261, y: -0.00000026226044, z: 0.00000022888183}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 867472138}
   m_Father: {fileID: 1017320153}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &561255719
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 248065651}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 60134579c9ddef44284c0dad35e2444d, type: 3}
@@ -4981,6 +5364,15 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 60134579c9ddef44284c0dad35e2444d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 561255722}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 60134579c9ddef44284c0dad35e2444d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 561255723}
   m_SourcePrefab: {fileID: 100100000, guid: 60134579c9ddef44284c0dad35e2444d, type: 3}
 --- !u!4 &561255720 stripped
 Transform:
@@ -5000,9 +5392,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 561255721}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.2
   m_Center: {x: -0.000000029802322, y: 0.000000029802322, z: 0.000000007450581}
 --- !u!114 &561255723
@@ -5018,6 +5418,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Sphere
+  guid: 8c11ac74-2594-41b2-a63d-c2a784985446
   tags: []
 --- !u!1 &576643108
 GameObject:
@@ -5043,12 +5444,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 576643108}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.27059805, y: -0.27059805, z: 0.6532815, w: 0.6532815}
   m_LocalPosition: {x: -0.1617, y: 0, z: 0.17999974}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: -45, z: 90}
 --- !u!136 &576643110
 CapsuleCollider:
@@ -5058,8 +5460,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 576643108}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -5069,6 +5480,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 813701130}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
@@ -5129,6 +5541,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: -7511558181221131132, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 586564674}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 586564672}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 586564673}
   m_SourcePrefab: {fileID: 100100000, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
 --- !u!4 &586564670 stripped
 Transform:
@@ -5153,6 +5577,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Podium Teleportation Area
+  guid: e31afc1d-b8eb-4008-9082-c746f35e400c
   tags: []
 --- !u!114 &586564673
 MonoBehaviour:
@@ -5175,6 +5600,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -5205,6 +5631,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -5260,9 +5698,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 586564671}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -3071651571934779511, guid: 67cd907787fe7884e9ee9dfbe4e68f5a, type: 3}
@@ -5298,12 +5744,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 587381658}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.01, y: 1.2, z: 0.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1756511964}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!114 &587381660
 MonoBehaviour:
@@ -5384,6 +5831,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -5414,6 +5862,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -5508,10 +5968,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 587381658}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -5525,9 +5996,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 587381658}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.40000013, y: 0.39999995, z: 0.20000006}
   m_Center: {x: 0.00000047683716, y: 0, z: -0.10000003}
 --- !u!23 &587381666
@@ -5541,6 +6020,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -5593,6 +6073,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Sliced Cube (1)
+  guid: 15781bd9-ec6f-4590-90f4-18bbcf8e0d01
   tags: []
 --- !u!1 &597715542
 GameObject:
@@ -5622,13 +6103,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 597715542}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.2, z: 0.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1106929324}
   m_Father: {fileID: 1527860102}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &597715544
 MonoBehaviour:
@@ -5699,9 +6181,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 597715542}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.4, y: 0.4, z: 0.4}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &597715546
@@ -5751,6 +6241,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Magic Cube_SnapZone
+  guid: e09bf7bf-4d29-456b-a29e-c6c5e8a11e33
   tags: []
 --- !u!1 &619832539
 GameObject:
@@ -5775,12 +6266,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 619832539}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0000000018626451, y: 0.000000005587936, z: -0.000000014901163, w: 1}
   m_LocalPosition: {x: -0.029552078, y: 0.0000000667572, z: -0.00000015109777}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1974977439}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &621906707
 GameObject:
@@ -5807,15 +6299,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 621906707}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.27542365, y: 0.27542365, z: 0.65126175, w: 0.65126175}
   m_LocalPosition: {x: 0.0358, y: 0.0577, z: -0.1296}
   m_LocalScale: {x: 0.95, y: 0.95, z: 0.95}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 236400690}
   - {fileID: 1482479233}
   - {fileID: 1822093055}
   m_Father: {fileID: 1833260103}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -45.848, y: 0, z: 90}
 --- !u!114 &621906709
 MonoBehaviour:
@@ -5881,18 +6374,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 622743095}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.36650118, y: 0, z: 0, w: 0.9304176}
   m_LocalPosition: {x: -0.0447, y: -0.0476, z: 0.0131}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 408361954}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 43, y: 0, z: 0}
 --- !u!1001 &632093759
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1527860102}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: e3168d03ba46dbe4eb56c62a2fcb9351, type: 3}
@@ -5956,6 +6451,15 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: e3168d03ba46dbe4eb56c62a2fcb9351, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1637849900}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e3168d03ba46dbe4eb56c62a2fcb9351, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 632093762}
   m_SourcePrefab: {fileID: 100100000, guid: e3168d03ba46dbe4eb56c62a2fcb9351, type: 3}
 --- !u!4 &632093760 stripped
 Transform:
@@ -5975,9 +6479,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 632093761}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.5000001, y: 1, z: 0.5000001}
   m_Center: {x: -0.00000023841858, y: 0.5, z: 0}
 --- !u!1 &634129204
@@ -6003,12 +6515,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 634129204}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0000000018626451, y: 0.000000005587936, z: -0.000000014901163, w: 1}
   m_LocalPosition: {x: -0.029552078, y: 0.0000000667572, z: -0.00000015109777}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 712045368}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &643048780
 GameObject:
@@ -6034,12 +6547,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 643048780}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.27059805, y: 0.27059805, z: 0.6532815, w: 0.6532815}
   m_LocalPosition: {x: -0.182, y: 0, z: -0.163}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 45, z: 90}
 --- !u!136 &643048782
 CapsuleCollider:
@@ -6049,8 +6563,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 643048780}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -6080,12 +6603,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 655638805}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 375530500}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &655638807
 MeshRenderer:
@@ -6098,6 +6622,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -6141,6 +6666,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1743725476}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
@@ -6228,6 +6754,45 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 844459427}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1769588068}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1359767051}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 576643109}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1816767294}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2140681947}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1423653693}
+    - targetCorrespondingSourceObject: {fileID: 393777075064552474, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 643048781}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2008175316}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2008175317}
+    - targetCorrespondingSourceObject: {fileID: 2191750151954457832, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 660021083}
+    - targetCorrespondingSourceObject: {fileID: 3396913584297481876, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1969415634}
   m_SourcePrefab: {fileID: 100100000, guid: acf8029ebcbe52b4488ed515778fc70b, type: 3}
 --- !u!4 &660021080 stripped
 Transform:
@@ -6252,9 +6817,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 660021082}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1.7976047, y: 1.1504669, z: 0.08324993}
   m_Center: {x: 0, y: 3.5952096, z: 0.01631552}
 --- !u!1 &673255606
@@ -6284,13 +6857,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 673255606}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 203271641}
   m_Father: {fileID: 1847977965}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &673255608
 MonoBehaviour:
@@ -6307,6 +6881,11 @@ MonoBehaviour:
   m_LineWidth: 0.02
   m_OverrideInteractorLineLength: 1
   m_LineLength: 10
+  m_AutoAdjustLineLength: 0
+  m_MinLineLength: 0.5
+  m_UseDistanceToHitAsMaxLineLength: 1
+  m_LineRetractionDelay: 0.5
+  m_LineLengthChangeSpeed: 12
   m_WidthCurve:
     serializedVersion: 2
     m_Curve:
@@ -6331,6 +6910,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  m_SetLineColorGradient: 1
   m_ValidColorGradient:
     serializedVersion: 2
     key0: {r: 0.47058824, g: 0.94509804, b: 0.78431374, a: 0}
@@ -6358,6 +6938,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_InvalidColorGradient:
@@ -6387,6 +6968,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 3
     m_NumAlphaKeys: 3
   m_BlockedColorGradient:
@@ -6416,6 +6998,7 @@ MonoBehaviour:
     atime6: 0
     atime7: 0
     m_Mode: 0
+    m_ColorSpace: -1
     m_NumColorKeys: 2
     m_NumAlphaKeys: 2
   m_TreatSelectionAsValidState: 0
@@ -6427,8 +7010,13 @@ MonoBehaviour:
   m_StopLineAtFirstRaycastHit: 1
   m_StopLineAtSelection: 0
   m_SnapEndpointIfAvailable: 1
+  m_LineBendRatio: 0.5
+  m_OverrideInteractorLineOrigin: 1
+  m_LineOriginTransform: {fileID: 0}
+  m_LineOriginOffset: 0
 --- !u!120 &673255609
 LineRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -6438,6 +7026,7 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -6522,16 +7111,20 @@ LineRenderer:
       atime6: 0
       atime7: 0
       m_Mode: 0
+      m_ColorSpace: -1
       m_NumColorKeys: 2
       m_NumAlphaKeys: 2
     numCornerVertices: 4
     numCapVertices: 4
     alignment: 0
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     shadowBias: 0.5
     generateLightingData: 0
+  m_MaskInteraction: 0
   m_UseWorldSpace: 1
   m_Loop: 0
+  m_ApplyActiveColorSpace: 0
 --- !u!114 &673255610
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6650,6 +7243,15 @@ MonoBehaviour:
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
   m_AnchorRotationMode: 0
+  m_UIHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_UIHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_EnableARRaycasting: 0
+  m_OccludeARHitsWith3DObjects: 0
+  m_OccludeARHitsWith2DObjects: 0
 --- !u!114 &673255611
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6695,6 +7297,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 5101698808175986029, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: ca6c2cc7-20f9-4bdc-8dc8-36edb0dcbcd0
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -6779,6 +7393,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: 37590f27-7e09-480e-9b9a-590a02a7ec22
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_HapticDeviceAction:
     m_UseReference: 1
     m_Action:
@@ -6851,13 +7477,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 684742641}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0037497291, y: 0.028980805, z: -0.08957866, w: 0.995551}
   m_LocalPosition: {x: -0.060953286, y: -0.00000024797393, z: 0.00000015258789}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1899651030}
   m_Father: {fileID: 1293420566}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &692521586
 GameObject:
@@ -6882,13 +7509,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 692521586}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7044048, y: 0.08700629, z: 0.3122117, w: 0.6314806}
   m_LocalPosition: {x: -0.042795867, y: -0.014722028, z: 0.029782485}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 698065486}
   m_Father: {fileID: 236400690}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &698065485
 GameObject:
@@ -6913,13 +7541,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 698065485}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.017132446, y: 0.023738552, z: -0.011670226, w: 0.9995033}
   m_LocalPosition: {x: -0.027674861, y: -0.00000018596648, z: 0.00000015173107}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 712045368}
   m_Father: {fileID: 692521587}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &702952329
 GameObject:
@@ -6944,13 +7573,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 702952329}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.007898328, y: 0.0033098771, z: -0.14792106, w: 0.9889621}
   m_LocalPosition: {x: -0.021837996, y: 0.000000052452087, z: 0.0000003004074}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 173879118}
   m_Father: {fileID: 277694094}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
@@ -7038,12 +7668,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.8864501, y: 0.40046445, z: 0.13547534, w: 0.18836364}
   m_LocalPosition: {x: 0, y: 5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 13.029, y: 156.335, z: 128.636}
 --- !u!1 &711695267
 GameObject:
@@ -7068,13 +7699,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 711695267}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.007229151, y: 0.004674483, z: -0.10485168, w: 0.9944506}
   m_LocalPosition: {x: -0.02966484, y: -0.00000024318695, z: 0.000000114440915}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1351890338}
   m_Father: {fileID: 1230062442}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &712045367
 GameObject:
@@ -7099,30 +7731,37 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 712045367}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0000025456518, y: 0.0000026570444, z: 0.10506754, w: 0.9944651}
   m_LocalPosition: {x: -0.03307885, y: 0.000000052452087, z: -0.00000030398368}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 634129205}
   m_Father: {fileID: 698065486}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!21 &738067764
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Standard
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _ALPHABLEND_ON
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -7162,6 +7801,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5
@@ -7176,7 +7816,7 @@ Material:
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 5
+    - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
@@ -7209,13 +7849,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 756951284}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1833260103}
   m_Father: {fileID: 1847977965}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &756951286
 SphereCollider:
@@ -7225,9 +7866,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 756951284}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.05
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &756951287
@@ -7315,6 +7964,11 @@ MonoBehaviour:
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
   m_AllowHoverHapticsWhileSelecting: 1
+  m_ImproveAccuracyWithSphereCollider: 0
+  m_PhysicsLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_PhysicsTriggerInteraction: 1
   precisionGrab: 1
 --- !u!114 &756951288
 MonoBehaviour:
@@ -7361,6 +8015,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 5101698808175986029, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: 066b2bad-dfb0-4811-9c05-bc63d6daf784
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -7445,6 +8111,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: 30f70ae2-0783-4d20-9b91-598807159dd1
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_HapticDeviceAction:
     m_UseReference: 1
     m_Action:
@@ -7519,12 +8197,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 757363299}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 0.1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1731060433}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &757363301
 MeshRenderer:
@@ -7537,6 +8216,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -7598,15 +8278,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 785961848}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1101317598}
   - {fileID: 1719448854}
   - {fileID: 1847977965}
   m_Father: {fileID: 2012349701}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &790520235
 GameObject:
@@ -7634,12 +8315,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 790520235}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1525491574}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &790520237
 MeshRenderer:
@@ -7652,6 +8334,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -7726,13 +8409,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 813252710}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.039005104, y: -0.077951096, z: -0.09432525, w: 0.9917182}
   m_LocalPosition: {x: -0.059387933, y: -0.00000024288892, z: 0.0000000011920929}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1017320153}
   m_Father: {fileID: 386644692}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &813701129
 GameObject:
@@ -7757,16 +8441,17 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 813701129}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 1.5, y: 0, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2014095924}
   - {fileID: 1241623310}
   - {fileID: 2121825122}
   - {fileID: 586564670}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &815556418
 GameObject:
@@ -7795,13 +8480,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 815556418}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1521703297}
   m_Father: {fileID: 1527860102}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &815556420
 MonoBehaviour:
@@ -7830,9 +8516,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 815556418}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 0.01, z: 1}
   m_Center: {x: 0, y: 0.02, z: 0}
 --- !u!114 &815556422
@@ -7856,6 +8550,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -7886,6 +8581,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -7947,6 +8654,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Teleportation Spot
+  guid: 2c0f9e99-8261-4525-811b-9daf58d0f127
   tags: []
 --- !u!1 &844459426
 GameObject:
@@ -7974,12 +8682,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 844459426}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 3, z: 0.36999983}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021080}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &844459428
 MonoBehaviour:
@@ -8006,6 +8715,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TargetCollider
+  guid: 6b1da8b3-2fce-426e-b540-e51864bcd03b
   tags: []
 --- !u!65 &844459430
 BoxCollider:
@@ -8015,9 +8725,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 844459426}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.35, y: 0.1, z: 0.35}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &853416177
@@ -8046,12 +8764,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 853416177}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.4, z: 1.8}
   m_LocalScale: {x: 0.04, y: 1, z: 0.04}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33704422}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &853416179
 MonoBehaviour:
@@ -8066,6 +8785,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Stair 1 Teleportation Area
+  guid: fad9c2db-6366-48ec-9355-ab593f05fe9d
   tags: []
 --- !u!114 &853416180
 MonoBehaviour:
@@ -8088,6 +8808,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -8118,6 +8839,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -8173,9 +8906,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 853416177}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -8205,12 +8946,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861048854}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.8, z: 2.2}
   m_LocalScale: {x: 0.04, y: 1, z: 0.04}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33704422}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &861048856
 MonoBehaviour:
@@ -8225,6 +8967,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Stair 2 Teleportation Area
+  guid: 2b82c762-a0fc-458a-9808-eed5c471260b
   tags: []
 --- !u!114 &861048857
 MonoBehaviour:
@@ -8247,6 +8990,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -8277,6 +9021,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -8332,9 +9088,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861048854}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -8345,7 +9109,7 @@ Mesh:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 10
+  serializedVersion: 11
   m_SubMeshes:
   - serializedVersion: 2
     firstByte: 0
@@ -8492,6 +9256,7 @@ Mesh:
     m_Center: {x: 0, y: 0, z: -0.09999999}
     m_Extent: {x: 0.19999997, y: 0.19999997, z: 0.09999999}
   m_MeshUsageFlags: 0
+  m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshMetrics[0]: 1.6879306
@@ -8525,12 +9290,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 867472137}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000029802326, y: 9.492409e-15, z: 0.00000031851238, w: 1}
   m_LocalPosition: {x: -0.02301526, y: 0.000000085830685, z: -0.000000114440915}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 548424074}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &873635843
 GameObject:
@@ -8555,13 +9321,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 873635843}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 520054713}
   m_Father: {fileID: 1518593211}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &906347379
 GameObject:
@@ -8586,12 +9353,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 906347379}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000029802326, y: 9.492409e-15, z: 0.00000031851238, w: 1}
   m_LocalPosition: {x: -0.02301526, y: 0.000000085830685, z: -0.000000114440915}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 130388568}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &941988690
 GameObject:
@@ -8616,18 +9384,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 941988690}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.2164396, y: 0, z: 0, w: 0.97629607}
   m_LocalPosition: {x: 0.0215, y: 0.0244, z: -0.0387}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 110401193}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 25, y: 0, z: 0}
 --- !u!1001 &1006305323
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 2121825122}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: e0eb73a744a54e74a98efc5eed3a5d4d, type: 3}
@@ -8683,6 +9453,15 @@ PrefabInstance:
       value: Shield
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: e0eb73a744a54e74a98efc5eed3a5d4d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1854500747}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e0eb73a744a54e74a98efc5eed3a5d4d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1831340547}
   m_SourcePrefab: {fileID: 100100000, guid: e0eb73a744a54e74a98efc5eed3a5d4d, type: 3}
 --- !u!1 &1017320152
 GameObject:
@@ -8707,13 +9486,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1017320152}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0029770152, y: -0.0028722505, z: -0.046370056, w: 0.9989158}
   m_LocalPosition: {x: -0.033406343, y: 0.00000032424927, z: -0.00000019073485}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 548424074}
   m_Father: {fileID: 813252711}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1101317597
 GameObject:
@@ -8743,12 +9523,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1101317597}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 785961849}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1101317599
 MonoBehaviour:
@@ -8763,7 +9544,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: User
+  guid: 114b0d36-6f12-4e0e-9fe5-b2a40e4da3d1
   tags: []
+  head: {fileID: 0}
+  leftHand: {fileID: 0}
+  rightHand: {fileID: 0}
 --- !u!114 &1101317600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8865,7 +9650,6 @@ MonoBehaviour:
       m_Action: Rotation
       m_Flags: 0
     m_Flags: 0
-  m_HasMigratedActions: 1
 --- !u!81 &1101317601
 AudioListener:
   m_ObjectHideFlags: 0
@@ -8896,9 +9680,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -8951,12 +9743,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1106929323}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 597715543}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1106929325
 MeshRenderer:
@@ -8969,6 +9762,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -9043,13 +9837,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1116639953}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0037497291, y: 0.028980805, z: -0.08957866, w: 0.995551}
   m_LocalPosition: {x: -0.060953286, y: -0.00000024797393, z: 0.00000015258789}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1197168314}
   m_Father: {fileID: 313596992}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1155200663
 GameObject:
@@ -9074,13 +9869,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1155200663}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.007898328, y: 0.0033098771, z: -0.14792106, w: 0.9889621}
   m_LocalPosition: {x: -0.021837996, y: 0.000000052452087, z: 0.0000003004074}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 154673132}
   m_Father: {fileID: 253252368}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1172561680
 GameObject:
@@ -9105,13 +9901,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1172561680}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99290055, y: -0.033564012, z: 0.11202527, w: 0.02173406}
   m_LocalPosition: {x: -0.048623275, y: 0.0027686262, z: -0.026522674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 182423184}
   m_Father: {fileID: 236400690}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1192304053
 GameObject:
@@ -9136,16 +9933,17 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1192304053}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1471223338}
   - {fileID: 1583804101}
   - {fileID: 2011926244}
   - {fileID: 535679137}
   m_Father: {fileID: 1527860102}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1193544125
 GameObject:
@@ -9170,12 +9968,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1193544125}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.00000002980233, y: -0.00000005308539, z: -0.000000042258765, w: 1}
   m_LocalPosition: {x: -0.022676239, y: 0.00000029563904, z: -0.000000077486035}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1339959895}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1197168313
 GameObject:
@@ -9200,19 +9999,21 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1197168313}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.00025817356, y: 0.00035699108, z: -0.14537643, w: 0.9893763}
   m_LocalPosition: {x: -0.036576994, y: 0.00000019073485, z: 0.0000001502037}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1831264167}
   m_Father: {fileID: 1116639954}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1204090590
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1756511964}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: aac080cbebbc8d744ad7320f8bb657c9, type: 3}
@@ -9276,6 +10077,9 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aac080cbebbc8d744ad7320f8bb657c9, type: 3}
 --- !u!4 &1204090591 stripped
 Transform:
@@ -9306,12 +10110,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1216574280}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0.4000002, y: 1.18, z: 0.6000003}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1756511964}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1216574282
 MonoBehaviour:
@@ -9326,6 +10131,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: LightSabre Origin
+  guid: 4d808e37-d2ed-4fd2-bbba-c3f0b7828e30
   tags: []
 --- !u!1 &1222594155
 GameObject:
@@ -9352,13 +10158,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1222594155}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 134998304}
   m_Father: {fileID: 1521703297}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &1222594157
 MeshRenderer:
@@ -9371,6 +10178,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -9432,13 +10240,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1230062441}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0013464622, y: -0.0029157132, z: -0.22192244, w: 0.9750591}
   m_LocalPosition: {x: -0.039041024, y: 0.0000006005168, z: 0.00000011503696}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 711695268}
   m_Father: {fileID: 24327722}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1241623309
 GameObject:
@@ -9471,12 +10280,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1241623309}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.5, y: 2.125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 813701130}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1241623311
 MonoBehaviour:
@@ -9537,6 +10347,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -9567,6 +10378,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -9667,6 +10490,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Ball
+  guid: 5934bdba-b8ba-404b-a626-cce9abaf8fef
   tags: []
 --- !u!54 &1241623315
 Rigidbody:
@@ -9675,10 +10499,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1241623309}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 0.01
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -9692,9 +10527,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1241623309}
   m_Material: {fileID: 13400000, guid: fb001adfa2edbb64887889d74d6fe41e, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.12
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1241623317
@@ -9708,6 +10551,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -9770,13 +10614,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1268751233}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.01, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1731060433}
   m_Father: {fileID: 232339300}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1268852335
 GameObject:
@@ -9802,12 +10647,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1268852335}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2015042050}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1268852337
 MonoBehaviour:
@@ -9846,13 +10692,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1293420565}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99804187, y: -0.04426889, z: 0.04315787, w: 0.009497783}
   m_LocalPosition: {x: -0.05238823, y: 0.0045133065, z: -0.011750946}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 684742642}
   m_Father: {fileID: 236400690}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1293635266
 GameObject:
@@ -9877,12 +10724,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1293635266}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000011175867, y: -0.000000022351747, z: -0.00000020395967, w: 1}
   m_LocalPosition: {x: -0.020554436, y: 0.000000114440915, z: -0.00000007867813}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1831264167}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1339959894
 GameObject:
@@ -9907,13 +10755,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1339959894}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.007229151, y: 0.004674483, z: -0.10485168, w: 0.9944506}
   m_LocalPosition: {x: -0.02966484, y: -0.00000024318695, z: 0.000000114440915}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1193544126}
   m_Father: {fileID: 393208952}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1351890337
 GameObject:
@@ -9938,12 +10787,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1351890337}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.00000002980233, y: -0.00000005308539, z: -0.000000042258765, w: 1}
   m_LocalPosition: {x: -0.022676239, y: 0.00000029563904, z: -0.000000077486035}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 711695268}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1359767050
 GameObject:
@@ -9969,12 +10819,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1359767050}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.27059805, y: 0.27059805, z: 0.6532815, w: 0.6532815}
   m_LocalPosition: {x: 0.1617, y: 0, z: 0.18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 45, z: 90}
 --- !u!136 &1359767052
 CapsuleCollider:
@@ -9984,8 +10835,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1359767050}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -10038,6 +10898,7 @@ MonoBehaviour:
     VRBuilder.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   selectedProcessStreamingAssetsPath: Processes/Demo - Core Features/Demo - Core
     Features.json
+  processStringLocalizationTable: VR Builder Demo
 --- !u!4 &1364604472
 Transform:
   m_ObjectHideFlags: 0
@@ -10045,12 +10906,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1364604469}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &1390574009
 Mesh:
@@ -10059,7 +10921,7 @@ Mesh:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 10
+  serializedVersion: 11
   m_SubMeshes:
   - serializedVersion: 2
     firstByte: 0
@@ -10206,6 +11068,7 @@ Mesh:
     m_Center: {x: 0, y: 0, z: -0.09999999}
     m_Extent: {x: 0.19999997, y: 0.19999997, z: 0.09999999}
   m_MeshUsageFlags: 0
+  m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshMetrics[0]: 1.6879306
@@ -10240,12 +11103,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1423653692}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.27059805, y: -0.27059805, z: 0.6532815, w: 0.6532815}
   m_LocalPosition: {x: 0.177, y: 0, z: -0.171}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: -45, z: 90}
 --- !u!136 &1423653694
 CapsuleCollider:
@@ -10255,8 +11119,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1423653692}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -10285,12 +11158,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1471223337}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0, y: 1.2, z: 1.125}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1192304054}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1471223339
 MonoBehaviour:
@@ -10305,6 +11179,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TransformerInside
+  guid: b28ccf67-674d-4dd0-8692-29d54dc16efc
   tags: []
 --- !u!1 &1482479232
 GameObject:
@@ -10330,12 +11205,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1482479232}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 621906708}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1482479234
 SkinnedMeshRenderer:
@@ -10348,6 +11224,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -10433,12 +11310,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1507460096}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0, y: 1.511, z: 1.142}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 535679137}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!108 &1507460098
 Light:
@@ -10528,13 +11406,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1518593210}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 873635844}
   m_Father: {fileID: 1719448854}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &1518593212
 SphereCollider:
@@ -10544,9 +11423,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1518593210}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.05
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &1518593213
@@ -10634,6 +11521,11 @@ MonoBehaviour:
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
   m_AllowHoverHapticsWhileSelecting: 1
+  m_ImproveAccuracyWithSphereCollider: 0
+  m_PhysicsLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_PhysicsTriggerInteraction: 1
   precisionGrab: 1
 --- !u!114 &1518593214
 MonoBehaviour:
@@ -10680,6 +11572,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 8248158260566104461, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_IsTrackedAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Is Tracked
+      m_Type: 1
+      m_ExpectedControlType: 
+      m_Id: 7aa0d0dd-43b4-41fd-b746-d03a05d1c84d
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 1
+    m_Reference: {fileID: 0}
   m_TrackingStateAction:
     m_UseReference: 0
     m_Action:
@@ -10764,6 +11668,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: 0}
+  m_UIScrollAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: UI Scroll
+      m_Type: 0
+      m_ExpectedControlType: Vector2
+      m_Id: c4aaa1df-8644-40e9-9b55-4ca2079eb5d3
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_HapticDeviceAction:
     m_UseReference: 1
     m_Action:
@@ -10836,13 +11752,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1521703296}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.01, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1222594156}
   m_Father: {fileID: 815556419}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1525491573
 GameObject:
@@ -10872,13 +11789,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1525491573}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0.8, z: 2.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 790520236}
   m_Father: {fileID: 33704422}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!114 &1525491575
 MonoBehaviour:
@@ -10949,9 +11867,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1525491573}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.4, y: 0.4, z: 0.2}
   m_Center: {x: 0, y: 0, z: -0.1}
 --- !u!114 &1525491577
@@ -11002,6 +11928,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Sliced Cube (1)_SnapZone_1
+  guid: 267cafb0-831f-443f-a1bc-0e3c407329d2
   tags: []
 --- !u!1 &1527860101
 GameObject:
@@ -11026,16 +11953,17 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1527860101}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -3, y: 0, z: 6}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 815556419}
   - {fileID: 597715543}
   - {fileID: 1192304054}
   - {fileID: 632093760}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &1573805701
 GameObject:
@@ -11060,13 +11988,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1573805701}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99290055, y: -0.033564012, z: 0.11202527, w: 0.02173406}
   m_LocalPosition: {x: -0.048623275, y: 0.0027686262, z: -0.026522674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 224249724}
   m_Father: {fileID: 1880869866}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1583804100
 GameObject:
@@ -11092,12 +12021,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1583804100}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.2, z: -0.25}
   m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1192304054}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1583804102
 MonoBehaviour:
@@ -11112,6 +12042,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TransformerOutside
+  guid: a7e020f0-7a47-475b-a47e-765b6320d381
   tags: []
 --- !u!1 &1584070613
 GameObject:
@@ -11136,13 +12067,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1584070613}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.99872494, y: -0.046419356, z: -0.015558949, w: -0.012318821}
   m_LocalPosition: {x: -0.05391815, y: 0.0050031445, z: 0.0017454529}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 24327722}
   m_Father: {fileID: 1880869866}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1634327992
 GameObject:
@@ -11167,12 +12099,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1634327992}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.000000011175867, y: -0.000000022351747, z: -0.00000020395967, w: 1}
   m_LocalPosition: {x: -0.020554436, y: 0.000000114440915, z: -0.00000007867813}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 119691936}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1637849899
 GameObject:
@@ -11197,12 +12130,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1637849899}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 632093760}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1685999354
 GameObject:
@@ -11227,13 +12161,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1685999354}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7044048, y: 0.08700629, z: 0.3122117, w: 0.6314806}
   m_LocalPosition: {x: -0.042795867, y: -0.014722028, z: 0.029782485}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3859427}
   m_Father: {fileID: 1880869866}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1719448853
 GameObject:
@@ -11259,15 +12194,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1719448853}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1518593211}
   - {fileID: 72067214}
   - {fileID: 408361954}
   m_Father: {fileID: 785961849}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1719448855
 MonoBehaviour:
@@ -11364,13 +12300,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731060432}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 757363300}
   m_Father: {fileID: 1268751234}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &1731060434
 MeshRenderer:
@@ -11383,6 +12320,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -11444,14 +12382,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1743725475}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 1.5, y: 0, z: -5.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 660021080}
   - {fileID: 2074732593}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &1745294526
 GameObject:
@@ -11479,12 +12418,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1745294526}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 221845637}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1745294528
 MeshRenderer:
@@ -11497,6 +12437,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -11571,9 +12512,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1756511963}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: -1, y: 0, z: 2.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 503181885}
   - {fileID: 232339300}
@@ -11583,7 +12526,6 @@ Transform:
   - {fileID: 102893252}
   - {fileID: 1204090591}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &1769588067
 GameObject:
@@ -11609,12 +12551,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1769588067}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0.244}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!136 &1769588069
 CapsuleCollider:
@@ -11624,8 +12567,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1769588067}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -11653,18 +12605,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1783782959}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.56707263, y: -0.5567243, z: -0.42857793, w: 0.42989275}
   m_LocalPosition: {x: -0.09850459, y: -0.018400598, z: -0.0062015653}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 520054713}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0.594, y: -105.251, z: -90.602}
 --- !u!1001 &1785665711
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 2121825122}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
@@ -11728,6 +12682,27 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665715}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665720}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665713}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665714}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665716}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1785665721}
   m_SourcePrefab: {fileID: 100100000, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
 --- !u!1 &1785665712 stripped
 GameObject:
@@ -11774,6 +12749,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -11804,6 +12780,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -11898,10 +12886,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1785665712}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -11920,6 +12919,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TouchPanel_1
+  guid: b7390fe8-8caa-4317-97a5-124258812e90
   tags: []
 --- !u!65 &1785665720
 BoxCollider:
@@ -11929,9 +12929,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1785665712}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.20000012, y: 0.2121321, z: 0.12727931}
   m_Center: {x: 0.00000023841858, y: 0.03535535, z: -0.06363918}
 --- !u!114 &1785665721
@@ -11977,13 +12985,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1794048750}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.039005104, y: -0.077951096, z: -0.09432525, w: 0.9917182}
   m_LocalPosition: {x: -0.059387933, y: -0.00000024288892, z: 0.0000000011920929}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1812729733}
   m_Father: {fileID: 533398623}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1812729732
 GameObject:
@@ -12008,13 +13017,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1812729732}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0029770152, y: -0.0028722505, z: -0.046370056, w: 0.9989158}
   m_LocalPosition: {x: -0.033406343, y: 0.00000032424927, z: -0.00000019073485}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 130388568}
   m_Father: {fileID: 1794048751}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1815494800
 GameObject:
@@ -12128,12 +13138,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1815494800}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1816767293
 GameObject:
@@ -12159,12 +13170,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1816767293}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 0.245, y: 0, z: -0.0040003136}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!136 &1816767295
 CapsuleCollider:
@@ -12174,8 +13186,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1816767293}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
@@ -12203,12 +13224,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1822093054}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.56707305, y: -0.556724, z: -0.42857817, w: 0.42989233}
   m_LocalPosition: {x: -0.09850973, y: 0.018401135, z: -0.006201879}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 621906708}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0.594, y: -105.251, z: -90.602}
 --- !u!1 &1831264166
 GameObject:
@@ -12233,13 +13255,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1831264166}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.0013731687, y: -0.0005792431, z: -0.08538537, w: 0.9963469}
   m_LocalPosition: {x: -0.028493328, y: -0.00000044822693, z: -0.0000003170967}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1293635267}
   m_Father: {fileID: 1197168314}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1831340543 stripped
 GameObject:
@@ -12264,6 +13287,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Shield
+  guid: e39efad2-fd32-469d-b9e2-c24cefdbdece
   tags: []
 --- !u!1 &1833260102
 GameObject:
@@ -12288,13 +13312,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1833260102}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 621906708}
   m_Father: {fileID: 756951285}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1847977964
 GameObject:
@@ -12320,15 +13345,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1847977964}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 756951285}
   - {fileID: 110401193}
   - {fileID: 673255607}
   m_Father: {fileID: 785961849}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1847977966
 MonoBehaviour:
@@ -12424,12 +13450,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1854500746}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.4, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1831340544}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!108 &1854500748
 Light:
@@ -12516,9 +13543,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1880869865}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 533398623}
   - {fileID: 1573805702}
@@ -12526,7 +13555,6 @@ Transform:
   - {fileID: 313596992}
   - {fileID: 1685999355}
   m_Father: {fileID: 520054713}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1883760418
 GameObject:
@@ -12551,13 +13579,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1883760418}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.00000005960466, y: 0.00999999, z: -0.000000059604638}
   m_LocalScale: {x: 0.99999976, y: 1, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 375530500}
   m_Father: {fileID: 2014095924}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1899651029
 GameObject:
@@ -12582,13 +13611,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899651029}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.00025817356, y: 0.00035699108, z: -0.14537643, w: 0.9893763}
   m_LocalPosition: {x: -0.036576994, y: 0.00000019073485, z: 0.0000001502037}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 119691936}
   m_Father: {fileID: 684742642}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1915479738
 GameObject:
@@ -12614,12 +13644,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1915479738}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2015042050}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1915479740
 MonoBehaviour:
@@ -12653,6 +13684,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Ring
+  guid: e76e9ea8-87bc-440f-b49c-054898d83560
   tags: []
 --- !u!1 &1974977438
 GameObject:
@@ -12677,19 +13709,21 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1974977438}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.0000025456518, y: 0.0000026570444, z: 0.10506754, w: 0.9944651}
   m_LocalPosition: {x: -0.03307885, y: 0.000000052452087, z: -0.00000030398368}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 619832540}
   m_Father: {fileID: 3859427}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1977887389
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 2011926244}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
@@ -12753,6 +13787,27 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887394}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887391}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887393}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887395}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887396}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887397}
   m_SourcePrefab: {fileID: 100100000, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
 --- !u!1 &1977887390 stripped
 GameObject:
@@ -12767,11 +13822,24 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1977887390}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.20000003, y: 0.2121321, z: 0.12727925}
   m_Center: {x: 0, y: 0.03535535, z: -0.063639626}
+--- !u!4 &1977887392 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 6db30c55efbe76c4c864604a925873d6, type: 3}
+  m_PrefabInstance: {fileID: 1977887389}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1977887393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12793,6 +13861,7 @@ MonoBehaviour:
     m_Bits: 1
   m_DistanceCalculationMode: 1
   m_SelectMode: 0
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 0}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -12823,6 +13892,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -12917,10 +13998,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1977887390}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -12939,6 +14031,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: TouchPanel
+  guid: 40468fd0-853c-4898-9a84-696dab43c741
   tags: []
 --- !u!114 &1977887396
 MonoBehaviour:
@@ -12984,6 +14077,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1756511964}
     m_Modifications:
     - target: {fileID: 5562819036174228372, guid: 871cf8bed45c27f46a347df0553bdcec, type: 3}
@@ -13035,6 +14129,9 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 871cf8bed45c27f46a347df0553bdcec, type: 3}
 --- !u!4 &1978455791 stripped
 Transform:
@@ -13065,12 +14162,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1999009288}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 520054713}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!137 &1999009290
 SkinnedMeshRenderer:
@@ -13083,6 +14181,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -13157,9 +14256,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2008175315}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 0.15393993, z: 1}
   m_Center: {x: 0, y: 0.07696997, z: 0}
 --- !u!65 &2008175317
@@ -13170,9 +14277,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2008175315}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 0.2, y: 3.5721025, z: 0.2}
   m_Center: {x: 0, y: 1.7860513, z: 0}
 --- !u!1001 &2011926243
@@ -13180,6 +14295,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1192304054}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d8aea3ae5508afb48a29b288fed4a3d1, type: 3}
@@ -13251,6 +14367,15 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2100000, guid: 2a4df160d58d76d4dac4a97bfb6dae35, type: 2}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: d8aea3ae5508afb48a29b288fed4a3d1, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1977887392}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d8aea3ae5508afb48a29b288fed4a3d1, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2011926246}
   m_SourcePrefab: {fileID: 100100000, guid: d8aea3ae5508afb48a29b288fed4a3d1, type: 3}
 --- !u!4 &2011926244 stripped
 Transform:
@@ -13275,6 +14400,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Button
+  guid: 59695741-bd1f-40a5-921b-9bad1edf702f
   tags: []
 --- !u!1 &2012349700
 GameObject:
@@ -13308,13 +14434,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2012349700}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 785961849}
   m_Father: {fileID: 2015042050}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2012349702
 MonoBehaviour:
@@ -13367,9 +14494,17 @@ CharacterController:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2012349700}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Height: 1.36144
   m_Radius: 0.1
   m_SlopeLimit: 45
@@ -13572,13 +14707,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2014095923}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.5, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1883760419}
   m_Father: {fileID: 813701130}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!114 &2014095925
 MonoBehaviour:
@@ -13612,6 +14748,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Teleportation Spot_2
+  guid: 7e6dd8e7-3de4-4d3e-95dd-23a6db7dbf83
   tags: []
 --- !u!65 &2014095927
 BoxCollider:
@@ -13621,9 +14758,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2014095923}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 0.01, z: 1}
   m_Center: {x: 0, y: 0.02, z: 0}
 --- !u!114 &2014095928
@@ -13647,6 +14792,7 @@ MonoBehaviour:
     m_Bits: 256
   m_DistanceCalculationMode: 1
   m_SelectMode: 1
+  m_FocusMode: 1
   m_CustomReticle: {fileID: 3819676577015031517, guid: c9ea54082e6151843acb776fb52ed6f7, type: 3}
   m_AllowGazeInteraction: 0
   m_AllowGazeSelect: 0
@@ -13677,6 +14823,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
     m_PersistentCalls:
       m_Calls: []
   m_Activated:
@@ -13748,33 +14906,40 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2015042049}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: -0.58, y: 0, z: 8.51}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2012349701}
   - {fileID: 1915479739}
   - {fileID: 1268852336}
   - {fileID: 325914045}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!21 &2018913513
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Standard
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _ALPHABLEND_ON
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -13814,6 +14979,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5
@@ -13828,7 +14994,7 @@ Material:
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 5
+    - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
@@ -13859,12 +15025,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2074732592}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 2.125, z: -3}
   m_LocalScale: {x: 0.2400001, y: 0.24, z: 0.2400001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1743725476}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2074732594
 MonoBehaviour:
@@ -13879,6 +15046,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueName: Ball origin
+  guid: c1444d9b-315d-418e-a90b-aa583e706d3a
   tags: []
 --- !u!1 &2096665700
 GameObject:
@@ -13903,12 +15071,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2096665700}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.2164396, y: 0, z: 0, w: 0.97629607}
   m_LocalPosition: {x: -0.0215, y: 0.0244, z: -0.0387}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 72067214}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 25, y: 0, z: 0}
 --- !u!43 &2119201252
 Mesh:
@@ -13917,7 +15086,7 @@ Mesh:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 10
+  serializedVersion: 11
   m_SubMeshes:
   - serializedVersion: 2
     firstByte: 0
@@ -14064,6 +15233,7 @@ Mesh:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0.19999997, y: 0.19999997, z: 0.19999997}
   m_MeshUsageFlags: 0
+  m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshMetrics[0]: 3.0308292
@@ -14092,9 +15262,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2121825121}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -4437772860958094431, guid: be0e1e3e3f7708e4ca1d7556ae7893bc, type: 3}
@@ -14122,12 +15300,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2140681946}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: -0.245, y: 0, z: -0.004}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 660021081}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!136 &2140681948
 CapsuleCollider:
@@ -14137,9 +15316,34 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2140681946}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.02
   m_Height: 0.2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1364604472}
+  - {fileID: 2015042050}
+  - {fileID: 1815494806}
+  - {fileID: 308985786}
+  - {fileID: 286338418}
+  - {fileID: 705507995}
+  - {fileID: 1527860102}
+  - {fileID: 1756511964}
+  - {fileID: 33704422}
+  - {fileID: 813701130}
+  - {fileID: 1743725476}
+  - {fileID: 248065651}

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetComponentEnabledBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetComponentEnabledBehavior.cs
@@ -109,9 +109,9 @@ namespace VRBuilder.Core.Behaviors
         {
         }
 
-        public SetComponentEnabledBehavior(string targetObject, string componentType, bool setEnabled, bool revertOnDeactivate)
+        public SetComponentEnabledBehavior(string guid, string componentType, bool setEnabled, bool revertOnDeactivate)
         {
-            Data.Target = new SceneObjectReference(targetObject);
+            Data.Target = new SceneObjectReference(guid);
             Data.ComponentType = componentType;
             Data.SetEnabled = setEnabled;
             Data.RevertOnDeactivation = revertOnDeactivate;

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetValueBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetValueBehavior.cs
@@ -61,7 +61,7 @@ namespace VRBuilder.Core.Behaviors
             /// <inheritdoc />
             public override IEnumerator Update()
             {
-                 yield return null;
+                yield return null;
             }
 
             /// <inheritdoc />
@@ -81,13 +81,13 @@ namespace VRBuilder.Core.Behaviors
         {
         }
 
-        public SetValueBehavior(string name) : this ("", default)
+        public SetValueBehavior(string name) : this("", default)
         {
         }
 
-        public SetValueBehavior(string propertyName, T value)
+        public SetValueBehavior(string guid, T value)
         {
-            Data.DataProperty = new ScenePropertyReference<IDataProperty<T>>(propertyName);
+            Data.DataProperty = new ScenePropertyReference<IDataProperty<T>>(guid);
             Data.NewValue = value;
         }
 

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Properties/ColliderWithTriggerProperty.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Properties/ColliderWithTriggerProperty.cs
@@ -1,6 +1,6 @@
 using System;
-using VRBuilder.Core.SceneObjects;
 using UnityEngine;
+using VRBuilder.Core.SceneObjects;
 
 namespace VRBuilder.Core.Properties
 {
@@ -25,13 +25,13 @@ namespace VRBuilder.Core.Properties
             Collider[] colliders = GetComponents<Collider>();
             if (colliders.Length == 0)
             {
-                Debug.LogErrorFormat("Object '{0}' with ColliderProperty must have at least one Collider attached.", SceneObject.UniqueName);
+                Debug.LogErrorFormat("Object '{0}' with ColliderProperty must have at least one Collider attached.", SceneObject.GameObject.name);
             }
             else
             {
                 if (CheckIfObjectHasTriggerCollider() == false)
                 {
-                    Debug.LogErrorFormat("Object '{0}' with ColliderProperty must have at least one Collider with isTrigger set to true.", SceneObject.UniqueName);
+                    Debug.LogErrorFormat("Object '{0}' with ColliderProperty must have at least one Collider with isTrigger set to true.", SceneObject.GameObject.name);
                 }
             }
         }
@@ -59,7 +59,7 @@ namespace VRBuilder.Core.Properties
             foreach (Collider collider in colliders)
             {
                 if (collider.enabled && collider.isTrigger)
-                {      
+                {
                     // If object and collider is in same position return true as it's not possible to raycast
                     if (collider.bounds.center == targetTransform.position)
                     {

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Properties/Data/DataProperty.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Properties/Data/DataProperty.cs
@@ -54,14 +54,14 @@ namespace VRBuilder.Core.Properties
         /// <inheritdoc/>
         public void SetValue(T value)
         {
-            if((storedValue == null && value == null) || value.Equals(storedValue))
+            if ((storedValue == null && value == null) || value.Equals(storedValue))
             {
                 return;
             }
 
-            if(LifeCycleLoggingConfig.Instance.LogDataPropertyChanges)
+            if (LifeCycleLoggingConfig.Instance.LogDataPropertyChanges)
             {
-                Debug.Log($"{ConsoleUtils.GetTabs()}<b>{GetType().Name}</b> on <i>'{SceneObject.UniqueName}'</i> changed from <b>{ValueToString(storedValue)}</b> to <b>{ValueToString(value)}</b>.\n");
+                Debug.Log($"{ConsoleUtils.GetTabs()}<b>{GetType().Name}</b> on <i>'{SceneObject.GameObject.name}'</i> changed from <b>{ValueToString(storedValue)}</b> to <b>{ValueToString(value)}</b>.\n");
             }
 
             storedValue = value;

--- a/Source/Core/Editor/UI/Drawers/SceneObjectTagDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SceneObjectTagDrawer.cs
@@ -42,7 +42,7 @@ namespace VRBuilder.Editor.UI.Drawers
             int selectedTagIndex = Array.IndexOf(tags, currentTag);
             bool isTagInvalid = false;
 
-            if(selectedTagIndex == -1)
+            if (selectedTagIndex == -1)
             {
                 selectedTagIndex = 0;
                 labels.Insert(0, noComponentSelected);
@@ -52,7 +52,7 @@ namespace VRBuilder.Editor.UI.Drawers
             selectedTagIndex = EditorGUI.Popup(guiLineRect, label.text, selectedTagIndex, labels.ToArray());
             EditorGUI.EndDisabledGroup();
 
-            if(isTagInvalid && selectedTagIndex == 0)
+            if (isTagInvalid && selectedTagIndex == 0)
             {
                 return rect;
             }
@@ -121,10 +121,10 @@ namespace VRBuilder.Editor.UI.Drawers
         {
             ISceneObject sceneObject = selectedSceneObject.GetComponent<ProcessSceneObject>() ?? selectedSceneObject.AddComponent<ProcessSceneObject>();
 
+            //TODO: Left this here during refactoring. Probably not needed after removing the UniqueName property
             if (RuntimeConfigurator.Configuration.SceneObjectRegistry.ContainsGuid(sceneObject.Guid) == false)
             {
-                // Sets a UniqueName and then registers it.
-                sceneObject.SetSuitableName();
+                RuntimeConfigurator.Configuration.SceneObjectRegistry.Register(sceneObject);
             }
 
             if (typeof(ISceneObjectProperty).IsAssignableFrom(valueType))

--- a/Source/Core/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -205,7 +205,7 @@ namespace VRBuilder.Editor.UI.Drawers
         {
             ISceneObject sceneObject = selectedSceneObject.GetComponent<ProcessSceneObject>() ?? selectedSceneObject.AddComponent<ProcessSceneObject>();
 
-            //TODO: Left this here during refactoring. Probably not needed after removing the UniqueName property
+            //TODO: Referencing - Left this here during refactoring. Probably not needed after removing the UniqueName property
             if (RuntimeConfigurator.Configuration.SceneObjectRegistry.ContainsGuid(sceneObject.Guid) == false)
             {
                 // Sets a UniqueName and then registers it.

--- a/Source/Core/Editor/UI/ProjectSettings/SceneObjectTagsSettingsSection.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/SceneObjectTagsSettingsSection.cs
@@ -43,18 +43,20 @@ namespace VRBuilder.Editor.UI
                 Guid guid = Guid.NewGuid();
 
                 RevertableChangesHandler.Do(new ProcessCommand(
-                    () => {
+                    () =>
+                    {
                         config.CreateTag(newLabel, guid);
                         EditorUtility.SetDirty(config);
                     },
-                    () => {
+                    () =>
+                    {
                         config.RemoveTag(guid);
                         EditorUtility.SetDirty(config);
                     }
                     ));
 
                 GUI.FocusControl("");
-                newLabel = "";                
+                newLabel = "";
             }
             EditorGUI.EndDisabledGroup();
             GUILayout.FlexibleSpace();
@@ -63,18 +65,18 @@ namespace VRBuilder.Editor.UI
             // List all tags
             foreach (SceneObjectTags.Tag tag in config.Tags)
             {
-                if(foldoutStatus.ContainsKey(tag) == false)
+                if (foldoutStatus.ContainsKey(tag) == false)
                 {
                     foldoutStatus.Add(tag, false);
                 }
 
                 IEnumerable<ISceneObject> objectsWithTag = RuntimeConfigurator.Configuration.SceneObjectRegistry.GetByTag(tag.Guid);
-                
+
                 GUILayout.BeginHorizontal();
 
                 // Foldout
                 EditorGUI.BeginDisabledGroup(objectsWithTag.Count() == 0);
-                
+
                 foldoutStatus[tag] = EditorGUILayout.Foldout(foldoutStatus[tag], "");
                 EditorGUI.EndDisabledGroup();
 
@@ -84,14 +86,16 @@ namespace VRBuilder.Editor.UI
                 // Label field
                 string newLabel = EditorGUILayout.TextField(label);
 
-                if(string.IsNullOrEmpty(newLabel) == false && newLabel != label)
+                if (string.IsNullOrEmpty(newLabel) == false && newLabel != label)
                 {
                     RevertableChangesHandler.Do(new ProcessCommand(
-                        () => {
+                        () =>
+                        {
                             config.RenameTag(tag, newLabel);
                             EditorUtility.SetDirty(config);
                         },
-                        () => {
+                        () =>
+                        {
                             config.RenameTag(tag, label);
                             EditorUtility.SetDirty(config);
                         }
@@ -104,11 +108,13 @@ namespace VRBuilder.Editor.UI
                 if (GUILayout.Button(deleteIcon.Texture, GUILayout.Height(EditorDrawingHelper.SingleLineHeight)))
                 {
                     RevertableChangesHandler.Do(new ProcessCommand(
-                        () => {
+                        () =>
+                        {
                             config.RemoveTag(tag.Guid);
                             EditorUtility.SetDirty(config);
                         },
-                        () => {
+                        () =>
+                        {
                             config.CreateTag(tag.Label, tag.Guid);
                             EditorUtility.SetDirty(config);
                         }
@@ -136,7 +142,7 @@ namespace VRBuilder.Editor.UI
                             EditorGUIUtility.PingObject(sceneObject.GameObject);
                         }
 
-                        GUILayout.Label($"{sceneObject.GameObject.name} - uid: {sceneObject.UniqueName}");
+                        GUILayout.Label($"{sceneObject.GameObject.name} - uid: {sceneObject.Guid}");
 
                         GUILayout.FlexibleSpace();
                         GUILayout.EndHorizontal();

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -76,9 +76,26 @@ namespace VRBuilder.Editor.UI
             if (targets.Count() == 1)
             {
                 EditorGUILayout.LabelField("Unique Id:");
+
                 EditorGUI.BeginDisabledGroup(true);
                 ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
-                EditorGUILayout.LabelField($"{sceneObject.Guid}");
+
+                // Check for override
+                bool isOverridden = IsPropertyOverridden("guid");
+
+                // Use a different style or color if overridden
+                GUIStyle labelStyle = isOverridden ? new GUIStyle(EditorStyles.label) { fontStyle = FontStyle.Bold } : EditorStyles.label;
+
+                Rect position = EditorGUILayout.GetControlRect();
+                if (isOverridden)
+                {
+                    DrawOverrideIndicator(position);
+                    position.x += 6; // Shift the content to the right a bit more to accommodate for the blue line
+                }
+
+                // Draw the guid using the adjusted position
+                EditorGUI.LabelField(position, $"{sceneObject.Guid}", labelStyle);
+
                 EditorGUI.EndDisabledGroup();
             }
             else
@@ -211,6 +228,30 @@ namespace VRBuilder.Editor.UI
 
                 EditorGUILayout.EndHorizontal();
             }
+        }
+
+        private bool IsPropertyOverridden(string propertyName)
+        {
+            if (PrefabUtility.IsPartOfPrefabInstance(target))
+            {
+                PropertyModification[] modifications = PrefabUtility.GetPropertyModifications(target);
+                foreach (PropertyModification mod in modifications)
+                {
+                    if (mod.propertyPath == propertyName)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private void DrawOverrideIndicator(Rect position)
+        {
+            Color originalColor = GUI.color;
+            GUI.color = new Color(0.26f, 0.59f, 0.98f, 1f); // Unity's blue
+            GUI.DrawTexture(new Rect(position.x, position.y, 2, position.height), EditorGUIUtility.whiteTexture);
+            GUI.color = originalColor;
         }
     }
 }

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -79,7 +79,10 @@ namespace VRBuilder.Editor.UI
                 EditorGUILayout.LabelField("Unique Id:");
 
                 ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
+
+                // TODO IsPropertyOverridden does not work correctly e.g.: after restarting unity
                 bool isOverridden = IsPropertyOverridden("guid");
+                //bool isOverridden = false;
                 DisplayPropertyWithOverrideIndicator($"{sceneObject.Guid}", isOverridden);
             }
             else

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -2,16 +2,15 @@
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
-using UnityEditor;
-using UnityEngine;
-using System.Reflection;
-using VRBuilder.Core.SceneObjects;
-using VRBuilder.Core.Properties;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+using VRBuilder.Core.Properties;
+using VRBuilder.Core.SceneObjects;
 using VRBuilder.Core.Settings;
-using VRBuilder.Editor.UndoRedo;
 
 namespace VRBuilder.Editor.UI
 {
@@ -31,11 +30,6 @@ namespace VRBuilder.Editor.UI
             ISceneObject sceneObject = target as ISceneObject;
             FieldInfo fieldInfoObj = sceneObject.GetType().GetField("uniqueName", BindingFlags.NonPublic | BindingFlags.Instance);
             string uniqueName = fieldInfoObj.GetValue(sceneObject) as string;
-
-            if (string.IsNullOrEmpty(uniqueName))
-            {
-                sceneObject.SetSuitableName();
-            }
 
             if (deleteIcon == null)
             {
@@ -63,20 +57,9 @@ namespace VRBuilder.Editor.UI
 
         public override void OnInspectorGUI()
         {
-            if(targets.Count() == 1)
+            if (targets.Count() == 1)
             {
-                ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
 
-                string oldName = sceneObject.UniqueName;
-                string name = EditorGUILayout.TextField("Unique Name", sceneObject.UniqueName);
-
-                if (name != sceneObject.UniqueName)
-                {
-                    RevertableChangesHandler.Do(new ProcessCommand(
-                        () => sceneObject.ChangeUniqueName(name),
-                        () => sceneObject.ChangeUniqueName(oldName)
-                        ));
-                }
             }
             else
             {
@@ -105,7 +88,7 @@ namespace VRBuilder.Editor.UI
                 SceneObjectTags.Instance.CreateTag(newTag, guid);
                 EditorUtility.SetDirty(SceneObjectTags.Instance);
 
-                foreach(ITagContainer container in tagContainers)
+                foreach (ITagContainer container in tagContainers)
                 {
                     Undo.RecordObject((UnityEngine.Object)container, "Added tag");
                     container.AddTag(guid);
@@ -198,6 +181,6 @@ namespace VRBuilder.Editor.UI
 
                 EditorGUILayout.EndHorizontal();
             }
-        }       
+        }
     }
 }

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using VRBuilder.Core.Properties;
@@ -27,10 +26,6 @@ namespace VRBuilder.Editor.UI
 
         private void OnEnable()
         {
-            ISceneObject sceneObject = target as ISceneObject;
-            FieldInfo fieldInfoObj = sceneObject.GetType().GetField("uniqueName", BindingFlags.NonPublic | BindingFlags.Instance);
-            string uniqueName = fieldInfoObj.GetValue(sceneObject) as string;
-
             if (deleteIcon == null)
             {
                 deleteIcon = new EditorIcon("icon_delete");
@@ -59,7 +54,11 @@ namespace VRBuilder.Editor.UI
         {
             if (targets.Count() == 1)
             {
-
+                ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
+                EditorGUILayout.LabelField("Unique Id:");
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUILayout.LabelField($"{sceneObject.Guid}");
+                EditorGUI.EndDisabledGroup();
             }
             else
             {

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -54,9 +54,9 @@ namespace VRBuilder.Editor.UI
         {
             if (targets.Count() == 1)
             {
-                ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
                 EditorGUILayout.LabelField("Unique Id:");
                 EditorGUI.BeginDisabledGroup(true);
+                ISceneObject sceneObject = targets.First(t => t is ISceneObject) as ISceneObject;
                 EditorGUILayout.LabelField($"{sceneObject.Guid}");
                 EditorGUI.EndDisabledGroup();
             }

--- a/Source/Core/Editor/UI/SceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/SceneObjectEditor.cs
@@ -52,6 +52,27 @@ namespace VRBuilder.Editor.UI
 
         public override void OnInspectorGUI()
         {
+            EditorGUI.BeginDisabledGroup(true);
+
+            // It can be a MonoBehaviour or a ScriptableObject
+            var monoScript = (target as MonoBehaviour) != null
+                ? MonoScript.FromMonoBehaviour((MonoBehaviour)target)
+                : MonoScript.FromScriptableObject((ScriptableObject)target);
+
+            EditorGUILayout.ObjectField("Script", monoScript, GetType(), false);
+
+            var monoScript2 = MonoScript.FromScriptableObject((ScriptableObject)this);
+
+            EditorGUILayout.ObjectField("EditorScript", monoScript2, GetType(), false);
+
+            EditorGUI.EndDisabledGroup();
+
+            DrawUniqueId();
+            DrawTags();
+        }
+
+        private void DrawUniqueId()
+        {
             if (targets.Count() == 1)
             {
                 EditorGUILayout.LabelField("Unique Id:");
@@ -64,15 +85,22 @@ namespace VRBuilder.Editor.UI
             {
                 EditorGUILayout.LabelField("[Multiple objects selected]");
             }
+        }
 
+        private void DrawTags()
+        {
             List<ITagContainer> tagContainers = targets.Where(t => t is ITagContainer).Cast<ITagContainer>().ToList();
 
             List<SceneObjectTags.Tag> availableTags = new List<SceneObjectTags.Tag>(SceneObjectTags.Instance.Tags);
 
-            EditorGUILayout.Space(EditorDrawingHelper.VerticalSpacing);
-
             EditorGUILayout.LabelField("Scene object tags:");
 
+            AddNewTag(tagContainers);
+            AddExistingTags(tagContainers, availableTags);
+        }
+
+        private void AddNewTag(List<ITagContainer> tagContainers)
+        {
             // Add and create new tag
             EditorGUILayout.BeginHorizontal();
 
@@ -100,7 +128,10 @@ namespace VRBuilder.Editor.UI
 
             EditorGUI.EndDisabledGroup();
             EditorGUILayout.EndHorizontal();
+        }
 
+        private void AddExistingTags(List<ITagContainer> tagContainers, List<SceneObjectTags.Tag> availableTags)
+        {
             foreach (SceneObjectTags.Tag tag in SceneObjectTags.Instance.Tags)
             {
                 if (tagContainers.All(c => c.HasTag(tag.Guid)))

--- a/Source/Core/Runtime/Exceptions/NameNotUniqueException.cs
+++ b/Source/Core/Runtime/Exceptions/NameNotUniqueException.cs
@@ -1,14 +1,16 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
+using System;
 using VRBuilder.Core.SceneObjects;
 
 namespace VRBuilder.Core.Exceptions
 {
+    [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4")]
     public class NameNotUniqueException : ProcessException
     {
-        public NameNotUniqueException(ISceneObject entity) : base(string.Format("Could not register Item with name '{0}', name already in use", entity.UniqueName))
+        public NameNotUniqueException(ISceneObject entity) : base(string.Format("Could not register Item with name '{0}', name already in use", entity.Guid))
         {
         }
     }

--- a/Source/Core/Runtime/Exceptions/PropertyNotFoundException.cs
+++ b/Source/Core/Runtime/Exceptions/PropertyNotFoundException.cs
@@ -1,15 +1,15 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
-﻿using System;
- using VRBuilder.Core.SceneObjects;
+using System;
+using VRBuilder.Core.SceneObjects;
 
- namespace VRBuilder.Core.Exceptions
+namespace VRBuilder.Core.Exceptions
 {
     public class PropertyNotFoundException : ProcessException
     {
         public PropertyNotFoundException(string message) : base(message) { }
-        public PropertyNotFoundException(ISceneObject sourceObject, Type missingType) : base(string.Format("SceneObject '{0}' does not contain a property of type '{1}'", sourceObject.UniqueName, missingType.Name)) { }
+        public PropertyNotFoundException(ISceneObject sourceObject, Type missingType) : base(string.Format("SceneObject '{0}' with id '{2}' does not contain a property of type '{1}'", sourceObject.GameObject.name, missingType.Name, sourceObject.Guid)) { }
     }
 }

--- a/Source/Core/Runtime/Properties/UserSceneObject.cs
+++ b/Source/Core/Runtime/Properties/UserSceneObject.cs
@@ -22,7 +22,7 @@ namespace VRBuilder.Core.Properties
         {
             get
             {
-                if(head == null)
+                if (head == null)
                 {
                     head = GetComponentInChildren<Camera>().transform;
                     Debug.LogWarning("User head object is not referenced on User Scene Object component. The rig's camera will be used, if available.");
@@ -41,11 +41,5 @@ namespace VRBuilder.Core.Properties
         /// Returns the user's right hand transform.
         /// </summary>
         public Transform RightHand => rightHand;
-
-        protected new void Awake()
-        {
-            base.Awake();
-            uniqueName = "User";
-        }
     }
 }

--- a/Source/Core/Runtime/SceneObjects/ISceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ISceneObject.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
-﻿using System;
+using System;
 using System.Collections.Generic;
-using VRBuilder.Core.Properties;
 using UnityEngine;
+using VRBuilder.Core.Properties;
 
 namespace VRBuilder.Core.SceneObjects
 {
@@ -26,8 +26,6 @@ namespace VRBuilder.Core.SceneObjects
     /// </summary>
     public interface ISceneObject : ILockable
     {
-        event EventHandler<SceneObjectNameChanged> UniqueNameChanged;
-
         /// <summary>
         /// Unique Guid for each entity, which is required
         /// </summary>
@@ -36,7 +34,8 @@ namespace VRBuilder.Core.SceneObjects
         /// <summary>
         /// Unique name which is not required
         /// </summary>
-        string UniqueName { get; }
+        [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4.  Guid string is returned as name.")]
+        string UniqueName { get => Guid.ToString(); }
 
         /// <summary>
         /// Target GameObject, used for applying stuff.
@@ -64,10 +63,5 @@ namespace VRBuilder.Core.SceneObjects
         /// Returns a property of the specified type.
         /// </summary>
         T GetProperty<T>() where T : ISceneObjectProperty;
-
-        /// <summary>
-        /// Attempts to change the scene object's unique name to the specified name.
-        /// </summary>        
-        void ChangeUniqueName(string newName);
     }
 }

--- a/Source/Core/Runtime/SceneObjects/ISceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ISceneObject.cs
@@ -9,18 +9,6 @@ using VRBuilder.Core.Properties;
 
 namespace VRBuilder.Core.SceneObjects
 {
-    public class SceneObjectNameChanged : EventArgs
-    {
-        public readonly string NewName;
-        public readonly string PreviousName;
-
-        public SceneObjectNameChanged(string newName, string previousName)
-        {
-            NewName = newName;
-            PreviousName = previousName;
-        }
-    }
-
     /// <summary>
     /// Gives the possibility to easily identify targets for Conditions, Behaviors and so on.
     /// </summary>

--- a/Source/Core/Runtime/SceneObjects/ISceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/ISceneObjectRegistry.cs
@@ -17,7 +17,8 @@ namespace VRBuilder.Core.SceneObjects
         /// <summary>
         /// Returns if the name is registered in the registry.
         /// </summary>
-        bool ContainsName(string name);
+        [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is returned as name.")]
+        bool ContainsName(string guid);
 
         /// <summary>
         /// Returns the IProcessSceneEntity belonging to the given Guid.
@@ -56,6 +57,7 @@ namespace VRBuilder.Core.SceneObjects
         /// <summary>
         /// Shortcut for GetByName(string name) method.
         /// </summary>
+        [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is returned as name.")]
         ISceneObject this[string name] { get; }
 
         /// <summary>

--- a/Source/Core/Runtime/SceneObjects/ISceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/ISceneObjectRegistry.cs
@@ -27,6 +27,14 @@ namespace VRBuilder.Core.SceneObjects
         ISceneObject GetByGuid(Guid guid);
 
         /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="guid">The guid of the ISceneObject to get.</param>
+        /// <param name="entity">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value.</param>
+        /// <returns>true if theRegistry contains an element with the specified key; otherwise, false.</returns>
+        bool TryGetGuid(Guid guid, out ISceneObject entity);
+
+        /// <summary>
         /// Returns the IProcessSceneEntity belonging to the given unique name.
         /// If there is no fitting Entity found a MissingEntityException will be thrown.
         /// </summary>

--- a/Source/Core/Runtime/SceneObjects/ObjectReference.cs
+++ b/Source/Core/Runtime/SceneObjects/ObjectReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
@@ -57,7 +57,7 @@ namespace VRBuilder.Core.SceneObjects
         {
         }
 
-        protected ObjectReference(string uniqueName) : base(uniqueName)
+        protected ObjectReference(string guid) : base(guid)
         {
         }
 

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -35,9 +35,9 @@ namespace VRBuilder.Core.SceneObjects
             }
         }
 
-        private const string NOT_INITIALIZED_GUID = "[not initialized guid]";
+        private const string notInitializedGuid = "[not initialized guid]";
         [SerializeField]
-        private string guid = NOT_INITIALIZED_GUID;
+        private string guid = notInitializedGuid;
 
         private List<IStepData> unlockers = new List<IStepData>();
 
@@ -54,7 +54,7 @@ namespace VRBuilder.Core.SceneObjects
 
                     // Can happen when opening old projects e.g.: for LightSabre in VR Builder Demo - Core Features
                     // TODO needs investigation
-                    if (guid != NOT_INITIALIZED_GUID)
+                    if (guid != notInitializedGuid)
                     {
                         Debug.LogError($"Guid of GamObject {gameObject.name} had an invalid value {guid} resetting it to {realGuid}. Expect follow up issues");
                     }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -33,18 +33,33 @@ namespace VRBuilder.Core.SceneObjects
         {
             get
             {
-                return guid.ToString();
+                return Guid.ToString();
             }
         }
 
         [SerializeField]
-        private Guid guid = Guid.NewGuid();
+        private string guid = string.Empty;
+
         private List<IStepData> unlockers = new List<IStepData>();
 
         /// <inheritdoc />
         public Guid Guid
         {
-            get { return guid; }
+            get
+            {
+                Guid realGuid;
+                if (!Guid.TryParse(guid, out realGuid))
+                {
+                    realGuid = Guid.NewGuid();
+
+                    if (guid != string.Empty)
+                    {
+                        Debug.LogWarning($"Guid of GamObject {gameObject.name} had an invalid value {guid} resetting it to {realGuid}.");
+                    }
+                    guid = realGuid.ToString();
+                }
+                return realGuid;
+            }
         }
 
         public ICollection<ISceneObjectProperty> Properties
@@ -103,6 +118,9 @@ namespace VRBuilder.Core.SceneObjects
                 return;
             }
 
+            //Ensure we have a valid guid
+            _ = Guid;
+
             RuntimeConfigurator.Configuration.SceneObjectRegistry.Register(this);
         }
 
@@ -143,7 +161,7 @@ namespace VRBuilder.Core.SceneObjects
                 // ReSharper disable once InvertIf
                 if (CheckHasProperty(propertyType) == false)
                 {
-                    Debug.LogErrorFormat("Property of type '{0}' is not attached to SceneObject '{1}' with id {2}", propertyType.Name, gameObject.name, guid);
+                    Debug.LogErrorFormat("Property of type '{0}' is not attached to SceneObject '{1}' with realGuid {2}", propertyType.Name, gameObject.name, Guid);
                     hasFailed = true;
                 }
             }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -25,11 +25,6 @@ namespace VRBuilder.Core.SceneObjects
         public event EventHandler<LockStateChangedEventArgs> Unlocked;
         public GameObject GameObject => gameObject;
 
-        [SerializeField]
-        [Tooltip("Unique name which identifies an object in scene, can be null or empty, but has to be unique in the scene.")]
-        [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4")]
-        protected string uniqueName = "Obsolete with VR-Builder 4";
-
         /// <inheritdoc />
         [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is returned as name.", true)]
         public string UniqueName
@@ -217,7 +212,7 @@ namespace VRBuilder.Core.SceneObjects
                 // ReSharper disable once InvertIf
                 if (CheckHasProperty(propertyType) == false)
                 {
-                    Debug.LogErrorFormat("Property of type '{0}' is not attached to SceneObject '{1}' with realGuid {2}", propertyType.Name, gameObject.name, Guid);
+                    Debug.LogErrorFormat("Property of type '{0}' is not attached to SceneObject '{1}' with guid {2}", propertyType.Name, gameObject.name, Guid);
                     hasFailed = true;
                 }
             }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -59,6 +59,10 @@ namespace VRBuilder.Core.SceneObjects
                         Debug.LogError($"Guid of GamObject {gameObject.name} had an invalid value {guid} resetting it to {realGuid}. Expect follow up issues");
                     }
                     guid = realGuid.ToString();
+
+#if UNITY_EDITOR
+                    EditorUtility.SetDirty(this);
+#endif
                 }
                 return realGuid;
             }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -54,9 +54,11 @@ namespace VRBuilder.Core.SceneObjects
                 Guid realGuid;
                 if (!Guid.TryParse(guid, out realGuid))
                 {
+                    // Generating a Guid when adding a new ProcessSceneObject to the scene
                     realGuid = Guid.NewGuid();
-                    Debug.LogWarning($"Generated new real Guid {realGuid} instead of existing {guid}");
 
+                    // Can happen when opening old projects e.g.: for LightSabre in VR Builder Demo - Core Features
+                    // TODO needs investigation
                     if (guid != NOT_INITIALIZED_GUID)
                     {
                         Debug.LogError($"Guid of GamObject {gameObject.name} had an invalid value {guid} resetting it to {realGuid}. Expect follow up issues");
@@ -93,7 +95,7 @@ namespace VRBuilder.Core.SceneObjects
 
         protected void Awake()
         {
-            Debug.Log($"Awake Finished for {this.name} from {Guid}");
+            // Debug.Log($"Awake Finished for {this.name} from {Guid}");
         }
 
         protected void Start()
@@ -109,28 +111,20 @@ namespace VRBuilder.Core.SceneObjects
                 }
             }
 
-            Debug.Log($"Start Finished for {this.name} from {Guid}");
-        }
-
-        protected void OnEnable()
-        {
-            Debug.Log($"OnEnable {this.name}, instanceID {gameObject.GetInstanceID()} Guid {Guid}");
+            // Debug.Log($"Start Finished for {this.name} - instanceID {gameObject.GetInstanceID()} from {Guid}");
         }
 
         protected void OnDisable()
         {
-            Debug.Log($"OnDisable {this.name}, instanceID {gameObject.GetInstanceID()} Guid {Guid}");
+            // Debug.Log($"OnDisable Finished for {this.name}, - instanceID {gameObject.GetInstanceID()} Guid {Guid}");
         }
 
         protected void Init()
         {
-            //Debug.Log($"Init {this.name}, PlayModeTracker.IsPlayMode {PlayModeTracker.IsPlayMode}");
-
 #if UNITY_EDITOR
 
             if (UnityEditor.SceneManagement.EditorSceneManager.IsPreviewScene(gameObject.scene))
             {
-                Debug.Log($"IsPreviewScene in {gameObject.name}. Returning");
                 return;
             }
 #endif
@@ -143,20 +137,20 @@ namespace VRBuilder.Core.SceneObjects
             //Ensure we have a valid guid
             _ = Guid;
 
-
-            // TODO we might want to also create an override if this is the first prefab / prefab variant in the open scenes
+            // TODO we might want to create an override if this is the first prefab / prefab variant in the open scenes
             ISceneObject obj;
             if (RuntimeConfigurator.Configuration.SceneObjectRegistry.TryGetGuid(Guid, out obj))
             {
+                // If we try to register the same object twice we return instead. Happen e.g.: when we open a scene because of SceneObjectRegistry.RegisterAll
                 if (obj.GameObject.GetInstanceID() == this.GameObject.GetInstanceID())
                 {
-                    Debug.Log($"Trying to register the same object twice {gameObject.name} - Guid {guid} - InstanceID {this.GameObject.GetInstanceID()} ");
+                    // Debug.Log($"Trying to register the same object twice {gameObject.name} - Guid {guid} - InstanceID {this.GameObject.GetInstanceID()} ");
                     return;
                 }
 
-                Debug.Log($"{gameObject.name} Guid {guid} already registered.");
+                // Debug.Log($"{gameObject.name} Guid {guid} already registered.");
                 guid = Guid.NewGuid().ToString();
-                Debug.Log($"Changed {gameObject.name} to guid {guid}");
+                // Debug.Log($"Changed {gameObject.name} to guid {guid}");
 
 #if UNITY_EDITOR
                 if (PrefabUtility.IsPartOfPrefabInstance(this))
@@ -164,7 +158,7 @@ namespace VRBuilder.Core.SceneObjects
                     var prefabInstance = PrefabUtility.GetOutermostPrefabInstanceRoot(this);
                     if (prefabInstance != null)
                     {
-                        Debug.Log($"Recording prefab override {this.name} from {guid}");
+                        // Debug.Log($"Recording prefab override {this.name} from {guid}");
                         PrefabUtility.RecordPrefabInstancePropertyModifications(prefabInstance);
                     }
                 }
@@ -176,7 +170,6 @@ namespace VRBuilder.Core.SceneObjects
 #if UNITY_EDITOR
             EditorUtility.SetDirty(this);
 #endif
-            Debug.Log($"Init Finished for {this.name} from {Guid}");
         }
 
         private void OnDestroy()
@@ -185,7 +178,6 @@ namespace VRBuilder.Core.SceneObjects
 
             if (UnityEditor.SceneManagement.EditorSceneManager.IsPreviewScene(gameObject.scene))
             {
-                Debug.Log($"IsPreviewScene in {this.name}. Returning");
                 return;
             }
 #endif

--- a/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectExtensions.cs
@@ -19,26 +19,6 @@ namespace VRBuilder.Core.Properties
     public static class SceneObjectExtensions
     {
         /// <summary>
-        /// Ensures that this <see cref="ISceneObject"/>'s UniqueName is not duplicated.
-        /// </summary>
-        /// <param name="sceneObject"><see cref="ISceneObject"/> to whom the `UniqueName` will be validated.</param>
-        /// <param name="baseName">Optional base for this <paramref name="sceneObject"/>'s `UniqueName`.</param>
-        public static void SetSuitableName(this ISceneObject sceneObject, string baseName = "")
-        {
-            int counter = 1;
-            string newName = baseName = string.IsNullOrEmpty(baseName) ? sceneObject.GameObject.name : baseName;
-
-            RuntimeConfigurator.Configuration.SceneObjectRegistry.Unregister(sceneObject);
-            while (RuntimeConfigurator.Configuration.SceneObjectRegistry.ContainsName(newName))
-            {
-                newName = string.Format("{0}_{1}", baseName, counter);
-                counter++;
-            }
-
-            sceneObject.ChangeUniqueName(newName);
-        }
-
-        /// <summary>
         /// Adds a <see cref="ISceneObjectProperty"/> of type <typeparamref name="T"/> into this <see cref="ISceneObject"/>.
         /// </summary>
         /// <param name="sceneObject"><see cref="ISceneObject"/> to whom the type <typeparamref name="T"/> will be added.</param>

--- a/Source/Core/Runtime/SceneObjects/SceneObjectReference.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectReference.cs
@@ -4,7 +4,6 @@
 
 using System.Runtime.Serialization;
 using VRBuilder.Core.Configuration;
-using UnityEngine;
 
 namespace VRBuilder.Core.SceneObjects
 {
@@ -18,7 +17,7 @@ namespace VRBuilder.Core.SceneObjects
         {
         }
 
-        public SceneObjectReference(string uniqueName) : base(uniqueName)
+        public SceneObjectReference(string guid) : base(guid)
         {
         }
 

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -77,29 +77,10 @@ namespace VRBuilder.Core.SceneObjects
             }
 
             registeredEntities.Add(obj.Guid, obj);
-            string allNamesAndGuids = string.Join("\n", registeredEntities.Select(pair =>
-            {
-                // Checks whether an object is null or Unity pseudo-null
-                // without having to cast to UnityEngine.Object manually
-                if (pair.Value == null || ((pair.Value is Object) && ((Object)pair.Value) == null))
-                {
-                    return $"{pair.Key} / [Deleted SceneObject]";
-                }
 
-                string gameObjectName = pair.Value?.GameObject?.name;
-                string guidInObject = pair.Value?.Guid.ToString();
+            //string registry = GetRegisteredEntitiesString();
+            //Debug.Log($"SceneObjectRegistry Register {obj.GameObject.name} from {obj.Guid}. {registry}");
 
-                if (pair.Key != pair.Value.Guid)
-                {
-                    Debug.LogWarning($"Invalid pair in SceneObjectRegistry {gameObjectName} Key: {pair.Key} - Object Guid {guidInObject}");
-                }
-
-                return $"{pair.Key} / {gameObjectName} / {guidInObject}";
-            }).ToArray());
-
-
-
-            Debug.Log($"SceneObjectRegistry Register {obj.GameObject.name} from {obj.Guid}.\nNew Registry:\n{allNamesAndGuids}");
         }
 
         /// <inheritdoc />
@@ -107,6 +88,18 @@ namespace VRBuilder.Core.SceneObjects
         {
             var succsesfulRemoved = registeredEntities.Remove(entity.Guid);
 
+            // string registry = GetRegisteredEntitiesString();
+            // Debug.Log($"SceneObjectRegistry Unregister {entity.GameObject.name} from {entity.Guid} was successful {succsesfulRemoved}.. {registry}");
+
+            return succsesfulRemoved;
+        }
+
+        /// <summary>
+        /// Write a log of the registeredEntities
+        /// </summary>
+        /// <param name="obj"></param>
+        private string GetRegisteredEntitiesString()
+        {
             string allNamesAndGuids = string.Join("\n", registeredEntities.Select(pair =>
             {
                 // Checks whether an object is null or Unity pseudo-null
@@ -126,9 +119,8 @@ namespace VRBuilder.Core.SceneObjects
 
                 return $"{pair.Key} / {gameObjectName} / {guidInObject}";
             }).ToArray());
-            Debug.Log($"SceneObjectRegistry Unregister {entity.GameObject.name} from {entity.Guid} was successful {succsesfulRemoved}.\nNew Registry:\n{allNamesAndGuids}");
 
-            return succsesfulRemoved;
+            return $"\nRegistry:\n{allNamesAndGuids}";
         }
 
         /// <inheritdoc />

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -96,7 +96,15 @@ namespace VRBuilder.Core.SceneObjects
         [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is used as name.")]
         public ISceneObject GetByName(string name)
         {
-            System.Guid convertedGuid = new Guid(name);
+            //TODO: Referencing - we need to handle old references (of unique names) properly
+            System.Guid convertedGuid;
+            bool isValid = Guid.TryParse(name, out convertedGuid);
+            if (!isValid)
+            {
+                Debug.LogErrorFormat("Could not parse '{0}' to System.Guid. We need to handle old references (of unique names) properly. ", name);
+                throw new MissingEntityException(string.Format("Could not find scene entity '{0}'", name));
+            }
+
             if (ContainsGuid(convertedGuid) == false)
             {
                 throw new MissingEntityException(string.Format("Could not find scene entity '{0}'", name));

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -150,12 +150,13 @@ namespace VRBuilder.Core.SceneObjects
                 throw new MissingEntityException(string.Format("Could not find scene entity '{0}'", name));
             }
 
-            if (ContainsGuid(convertedGuid) == false)
+            ISceneObject obj = default;
+            if (!TryGetGuid(convertedGuid, out obj))
             {
                 throw new MissingEntityException(string.Format("Could not find scene entity '{0}'", name));
             }
 
-            return registeredEntities.GetValueOrDefault(convertedGuid);
+            return obj;
         }
 
         /// <inheritdoc />

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -76,12 +76,15 @@ namespace VRBuilder.Core.SceneObjects
                 throw new AlreadyRegisteredException(obj);
             }
 
+            Debug.Log($"Register {obj.GameObject.name} from {obj.Guid}");
+
             registeredEntities.Add(obj.Guid, obj);
         }
 
         /// <inheritdoc />
         public bool Unregister(ISceneObject entity)
         {
+            Debug.Log($"Unregister {entity.GameObject.name} from {entity.Guid}");
             return registeredEntities.Remove(entity.Guid);
         }
 

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -98,10 +98,15 @@ namespace VRBuilder.Core.SceneObjects
         {
             //TODO: Referencing - we need to handle old references (of unique names) properly
             System.Guid convertedGuid;
-            bool isValid = Guid.TryParse(name, out convertedGuid);
-            if (!isValid)
+            bool isGuid = Guid.TryParse(name, out convertedGuid);
+            if (!isGuid)
             {
-                Debug.LogErrorFormat("Could not parse '{0}' to System.Guid. We need to handle old references (of unique names) properly. ", name);
+                GlobalObjectId convertedUnityGUnityUid;
+                bool isGuuid = GlobalObjectId.TryParse(name, out convertedUnityGUnityUid);
+                if (!isGuuid)
+                {
+                    Debug.LogWarningFormat("Could not parse '{0}' to System.Guid. We need to handle old references (of unique names) properly. ", name);
+                }
                 throw new MissingEntityException(string.Format("Could not find scene entity '{0}'", name));
             }
 

--- a/Source/Core/Runtime/SceneObjects/ScenePropertyReference.cs
+++ b/Source/Core/Runtime/SceneObjects/ScenePropertyReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
@@ -25,7 +25,7 @@ namespace VRBuilder.Core.SceneObjects
         {
         }
 
-        public ScenePropertyReference(string uniqueName) : base(uniqueName)
+        public ScenePropertyReference(string guid) : base(guid)
         {
         }
 

--- a/Source/Core/Runtime/SceneObjects/UniqueNameReference.cs
+++ b/Source/Core/Runtime/SceneObjects/UniqueNameReference.cs
@@ -10,6 +10,7 @@ namespace VRBuilder.Core.SceneObjects
     /// <summary>
     /// Simple container for UniqueName.
     /// </summary>
+    //TODO: Referencing - we need to handle old references (of unique names) and empty "" references
     [DataContract(IsReference = true)]
     [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is used as unique identifier..")]
     public abstract class UniqueNameReference

--- a/Source/Core/Runtime/SceneObjects/UniqueNameReference.cs
+++ b/Source/Core/Runtime/SceneObjects/UniqueNameReference.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
-﻿using System;
- using System.Runtime.Serialization;
+using System;
+using System.Runtime.Serialization;
 
 namespace VRBuilder.Core.SceneObjects
 {
@@ -11,12 +11,14 @@ namespace VRBuilder.Core.SceneObjects
     /// Simple container for UniqueName.
     /// </summary>
     [DataContract(IsReference = true)]
+    [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is used as unique identifier..")]
     public abstract class UniqueNameReference
     {
         /// <summary>
         /// Serializable unique name of referenced object.
         /// </summary>
         [DataMember]
+        [Obsolete("Support for ISceneObject.UniqueName will be removed with VR-Builder 4. Guid string is used as unique identifier.")]
         public virtual string UniqueName { get; set; }
 
         protected UniqueNameReference() { }

--- a/Source/Core/Runtime/Utils/ProcessReferenceUtils.cs
+++ b/Source/Core/Runtime/Utils/ProcessReferenceUtils.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2023 MindPort GmbH
 
-using VRBuilder.Core.SceneObjects;
 using VRBuilder.Core.Properties;
+using VRBuilder.Core.SceneObjects;
 
 namespace VRBuilder.Core.Utils
 {
@@ -21,7 +21,7 @@ namespace VRBuilder.Core.Utils
                 return null;
             }
 
-            return property.SceneObject.UniqueName;
+            return property.SceneObject.GameObject.name;
         }
 
         public static string GetNameFrom(ISceneObject sceneObject)
@@ -31,7 +31,7 @@ namespace VRBuilder.Core.Utils
                 return null;
             }
 
-            return sceneObject.UniqueName;
+            return sceneObject.GameObject.name;
         }
     }
 }

--- a/Source/XR-Interaction-Component/Source/Runtime/Properties/SnapZoneProperty.cs
+++ b/Source/XR-Interaction-Component/Source/Runtime/Properties/SnapZoneProperty.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.XR.Interaction.Toolkit;
-using VRBuilder.Core.Properties;
-using VRBuilder.Core.Configuration.Modes;
-using VRBuilder.BasicInteraction.Properties;
 using UnityEngine.Events;
+using UnityEngine.XR.Interaction.Toolkit;
+using VRBuilder.BasicInteraction.Properties;
+using VRBuilder.Core.Configuration.Modes;
+using VRBuilder.Core.Properties;
 
 namespace VRBuilder.XRInteraction.Properties
 {
@@ -48,7 +48,7 @@ namespace VRBuilder.XRInteraction.Properties
         /// <summary>
         /// Returns the SnapZone component.
         /// </summary>
-        public SnapZone SnapZone 
+        public SnapZone SnapZone
         {
             get
             {
@@ -66,15 +66,15 @@ namespace VRBuilder.XRInteraction.Properties
         public UnityEvent<SnapZonePropertyEventArgs> ObjectDetached => objectDetached;
 
         private SnapZone snapZone;
-        
+
         protected override void OnEnable()
         {
             base.OnEnable();
-        
+
             SnapZone.selectEntered.AddListener(HandleObjectSnapped);
             SnapZone.selectExited.AddListener(HandleObjectUnsnapped);
         }
-        
+
         protected override void OnDisable()
         {
             base.OnDisable();
@@ -82,21 +82,21 @@ namespace VRBuilder.XRInteraction.Properties
             SnapZone.selectEntered.RemoveListener(HandleObjectSnapped);
             SnapZone.selectExited.RemoveListener(HandleObjectUnsnapped);
         }
-        
+
         private void HandleObjectSnapped(SelectEnterEventArgs arguments)
         {
             XRBaseInteractable interactable = arguments.interactableObject as XRBaseInteractable;
             SnappedObject = interactable.gameObject.GetComponent<SnappableProperty>();
             if (SnappedObject == null)
             {
-                Debug.LogWarningFormat("SnapZone '{0}' received snap from object '{1}' without XR_SnappableProperty", SceneObject.UniqueName, interactable.gameObject.name);
+                Debug.LogWarningFormat("SnapZone '{0}' received snap from object '{1}' without XR_SnappableProperty", SceneObject.GameObject.name, interactable.gameObject.name);
             }
             else
             {
                 EmitSnapped();
             }
         }
-        
+
         private void HandleObjectUnsnapped(SelectExitEventArgs arguments)
         {
             if (SnappedObject != null)
@@ -111,7 +111,7 @@ namespace VRBuilder.XRInteraction.Properties
                 RequestLocked(true);
             }
         }
-        
+
         private void InitializeModeParameters()
         {
             if (IsShowingHoverMeshes == null)
@@ -141,7 +141,7 @@ namespace VRBuilder.XRInteraction.Properties
                 };
             }
         }
-        
+
         /// <summary>
         /// Configure snap zone properties according to the provided mode.
         /// </summary>
@@ -154,7 +154,7 @@ namespace VRBuilder.XRInteraction.Properties
             IsShowingHighlightObject.Configure(mode);
             HighlightMaterial.Configure(mode);
         }
-        
+
         /// <summary>
         /// Invokes the <see cref="EmitSnapped"/> event.
         /// </summary>

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/ConfettiBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/ConfettiBehaviorTests.cs
@@ -1,15 +1,14 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections;
-using VRBuilder.Core.Behaviors;
-using VRBuilder.Core.Configuration.Modes;
-using VRBuilder.Core.SceneObjects;
-
-using VRBuilder.Tests.Utils;
-using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Object = UnityEngine.Object;
+using VRBuilder.Core.Behaviors;
+using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.ProcessUtils;
+using VRBuilder.Core.SceneObjects;
+using VRBuilder.Tests.Utils;
+using Object = UnityEngine.Object;
 
 namespace VRBuilder.Core.Tests.Behaviors
 {
@@ -28,7 +27,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given the path to the confetti machine prefab, the position provider name, the duration, the bool isAboveUser, the area radius, and the activation mode,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             BehaviorExecutionStages executionStages = BehaviorExecutionStages.ActivationAndDeactivation;
 
@@ -39,7 +37,7 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Then all properties of the ConfettiBehavior are properly assigned
             Assert.AreEqual(false, confettiBehavior.Data.IsAboveUser);
             Assert.AreEqual(positionProvider, confettiBehavior.Data.PositionProvider.Value);
-            Assert.AreEqual(pathToPrefab,confettiBehavior.Data.ConfettiMachinePrefabPath);
+            Assert.AreEqual(pathToPrefab, confettiBehavior.Data.ConfettiMachinePrefabPath);
             Assert.AreEqual(areaRadius, confettiBehavior.Data.AreaRadius);
             Assert.AreEqual(duration, confettiBehavior.Data.Duration);
             Assert.AreEqual(executionStages, confettiBehavior.Data.ExecutionStages);
@@ -53,7 +51,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given the path to the confetti machine prefab, the position provider name, the duration, the bool isAboveUser, the area radius, and the activation mode,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             BehaviorExecutionStages executionStages = BehaviorExecutionStages.ActivationAndDeactivation;
 
@@ -64,7 +61,7 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Then all properties of the MoveObjectBehavior are properly assigned.
             Assert.AreEqual(false, confettiBehavior.Data.IsAboveUser);
             Assert.AreEqual(positionProvider, confettiBehavior.Data.PositionProvider.Value);
-            Assert.AreEqual(pathToMockPrefab,confettiBehavior.Data.ConfettiMachinePrefabPath);
+            Assert.AreEqual(pathToMockPrefab, confettiBehavior.Data.ConfettiMachinePrefabPath);
             Assert.AreEqual(areaRadius, confettiBehavior.Data.AreaRadius);
             Assert.AreEqual(duration, confettiBehavior.Data.Duration);
             Assert.AreEqual(executionStages, confettiBehavior.Data.ExecutionStages);
@@ -78,7 +75,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given a positive duration, a position provider, some valid default settings, and the activation mode = Activation,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -92,7 +88,7 @@ namespace VRBuilder.Core.Tests.Behaviors
                 behavior.Update();
             }
 
-            ConfettiMachine machine = GameObject.FindObjectOfType<ConfettiMachine>();    
+            ConfettiMachine machine = GameObject.FindObjectOfType<ConfettiMachine>();
 
             // Then the activation state of the behavior is "activating" and the ConfettiMachine exists in the scene.
             Assert.AreEqual(Stage.Activating, behavior.LifeCycle.Stage);
@@ -105,7 +101,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given a positive duration, a position provider, some valid default settings, and the activation mode = Activation,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -143,7 +138,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, newDuration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -181,7 +175,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, newDuration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -221,7 +214,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             GameObject target = new GameObject(positionProviderName);
             target.transform.position = new Vector3(5, 10, 20);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -251,7 +243,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given the position provider process object, some valid default settings, and the activation mode = Activation,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, 2f, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -282,7 +273,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given the position provider process object, some valid default settings, and the activation mode = Activation,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -317,7 +307,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given the position provider process object, an invalid path to a not existing prefab, some valid default settings, and the activation mode = Activation,
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToMockPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -348,7 +337,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given a ConfettiBehavior with activation mode "Activation",
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -368,7 +356,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given a ConfettiBehavior with activation mode "Activation",
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -389,7 +376,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given a ConfettiBehavior with activation mode "Deactivation",
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Deactivation);
             behavior.Configure(defaultMode);
@@ -416,7 +402,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given an active ConfettiBehavior with activation mode "Activation",
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Activation);
             behavior.Configure(defaultMode);
@@ -442,7 +427,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given an active ConfettiBehavior with activation mode "Deactivation",
             GameObject target = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             ConfettiBehavior behavior = new ConfettiBehavior(false, positionProvider, pathToPrefab, areaRadius, duration, BehaviorExecutionStages.Deactivation);
             behavior.Configure(defaultMode);

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/LockBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/LockBehaviorTests.cs
@@ -1,11 +1,11 @@
+using NUnit.Framework;
 using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Tests.Utils;
-using UnityEngine.TestTools;
-using UnityEngine;
-using NUnit.Framework;
 
 namespace VRBuilder.Core.Tests.Behaviors
 {
@@ -20,7 +20,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given an game object with a changed unique name,
             GameObject gameObject = new GameObject("Test");
             ProcessSceneObject targetObject = gameObject.AddComponent<ProcessSceneObject>();
-            targetObject.ChangeUniqueName(targetName);
 
             // When we reference it by reference or unique name in the LockObjectBehavior,
             LockObjectBehavior lock1 = new LockObjectBehavior(targetObject);

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/MoveObjectBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/MoveObjectBehaviorTests.cs
@@ -1,11 +1,11 @@
+using NUnit.Framework;
 using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Tests.Utils;
-using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace VRBuilder.Core.Tests.Behaviors
 {
@@ -20,11 +20,9 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given two process objects and a duration,
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject targetGo = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = targetGo.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             float duration = 0.25f;
 
@@ -34,7 +32,7 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Then all properties of the MoveObjectBehavior are properly assigned
             Assert.AreEqual(moved, moveObjectBehavior.Data.Target.Value);
             Assert.AreEqual(positionProvider, moveObjectBehavior.Data.PositionProvider.Value);
-            Assert.AreEqual(moveObjectBehavior.Data.Duration,duration);
+            Assert.AreEqual(moveObjectBehavior.Data.Duration, duration);
 
             // Cleanup created game objects.
             Object.DestroyImmediate(movedGo);
@@ -49,11 +47,9 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given two process objects and a duration,
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject targetGo = new GameObject(positionProviderName);
             ProcessSceneObject positionProvider = targetGo.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             float duration = 0.25f;
 
@@ -63,7 +59,7 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Then all properties of the MoveObjectBehavior are properly assigned
             Assert.AreEqual(moved, moveObjectBehavior.Data.Target.Value);
             Assert.AreEqual(positionProvider, moveObjectBehavior.Data.PositionProvider.Value);
-            Assert.AreEqual(moveObjectBehavior.Data.Duration,duration);
+            Assert.AreEqual(moveObjectBehavior.Data.Duration, duration);
 
             // Cleanup created game objects.
             Object.DestroyImmediate(movedGo);
@@ -80,13 +76,11 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject positionProviderGo = new GameObject(positionProviderName);
             positionProviderGo.transform.position = new Vector3(1, 2, 50);
             positionProviderGo.transform.rotation = Quaternion.Euler(57, 195, 188);
             ProcessSceneObject target = positionProviderGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
             behavior.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
@@ -120,13 +114,11 @@ namespace VRBuilder.Core.Tests.Behaviors
             float duration = -2.5f;
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject positionProviderGameObject = new GameObject(positionProviderName);
             positionProviderGameObject.transform.position = new Vector3(1, 2, 50);
             positionProviderGameObject.transform.rotation = Quaternion.Euler(123, 15, 8);
             ProcessSceneObject positionProvider = positionProviderGameObject.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, positionProvider, duration);
             behavior.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
@@ -157,13 +149,11 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject targetGo = new GameObject(positionProviderName);
             targetGo.transform.position = new Vector3(1, 2, 50);
             targetGo.transform.rotation = Quaternion.Euler(123, 15, 8);
             ProcessSceneObject target = targetGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
             behavior.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
@@ -194,11 +184,9 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject targetGo = new GameObject(positionProviderName);
             ProcessSceneObject target = targetGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
             behavior.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
@@ -227,13 +215,11 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject positionProviderGo = new GameObject(positionProviderName);
             positionProviderGo.transform.position = new Vector3(1, 2, 50);
             positionProviderGo.transform.rotation = Quaternion.Euler(57, 195, 188);
             ProcessSceneObject target = positionProviderGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
 
@@ -258,13 +244,11 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject positionProviderGo = new GameObject(positionProviderName);
             positionProviderGo.transform.position = new Vector3(1, 2, 50);
             positionProviderGo.transform.rotation = Quaternion.Euler(57, 195, 188);
             ProcessSceneObject target = positionProviderGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
 
@@ -292,13 +276,11 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject movedGo = new GameObject(movedName);
             ProcessSceneObject moved = movedGo.AddComponent<ProcessSceneObject>();
-            moved.ChangeUniqueName(movedName);
 
             GameObject positionProviderGo = new GameObject(positionProviderName);
             positionProviderGo.transform.position = new Vector3(1, 2, 50);
             positionProviderGo.transform.rotation = Quaternion.Euler(57, 195, 188);
             ProcessSceneObject target = positionProviderGo.AddComponent<ProcessSceneObject>();
-            target.ChangeUniqueName(positionProviderName);
 
             MoveObjectBehavior behavior = new MoveObjectBehavior(moved, target, duration);
 

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/ScalingBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/ScalingBehaviorTests.cs
@@ -1,11 +1,11 @@
+using NUnit.Framework;
 using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Tests.Utils;
-using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace VRBuilder.Core.Tests.Behaviors
 {
@@ -23,7 +23,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 
@@ -64,7 +63,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 
@@ -96,7 +94,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 
@@ -130,7 +127,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = Vector3.zero;
 
@@ -162,7 +158,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = new Vector3(-1, -1, -1);
 
@@ -194,7 +189,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 
@@ -219,7 +213,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 
@@ -245,7 +238,6 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             GameObject target = new GameObject(targetName);
             ProcessSceneObject positionProvider = target.AddComponent<ProcessSceneObject>();
-            positionProvider.ChangeUniqueName(targetName);
 
             Vector3 endScale = target.transform.localScale + newScale;
 

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/SetComponentEnabledBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/SetComponentEnabledBehaviorTests.cs
@@ -61,20 +61,20 @@ namespace VRBuilder.Core.Tests.Behaviors
             Assert.AreEqual(revert, behavior.Data.RevertOnDeactivation);
 
             yield break;
-        }      
+        }
 
         [UnityTest]
         public IEnumerator CreateByName()
         {
             // Given the necessary parameters,
             ISceneObject targetObject = CreateTargetObject();
-            string targetName = targetObject.UniqueName;
+            string guid = targetObject.Guid.ToString();
             string componentType = "BoxCollider";
             bool enable = true;
             bool revert = true;
 
             // When we create the behavior passing process objects by name,
-            SetComponentEnabledBehavior behavior = new SetComponentEnabledBehavior(targetName, componentType, enable, revert);
+            SetComponentEnabledBehavior behavior = new SetComponentEnabledBehavior(guid, componentType, enable, revert);
 
             // Then all properties of the behavior are properly assigned.
             Assert.AreEqual(targetObject, behavior.Data.Target.Value);
@@ -106,7 +106,7 @@ namespace VRBuilder.Core.Tests.Behaviors
 
             // Then the target components are disabled.
             Assert.IsTrue(spawnedObject.GameObject.GetComponents<BoxCollider>().Length > 0);
-            foreach(BoxCollider collider in spawnedObject.GameObject.GetComponents<BoxCollider>())
+            foreach (BoxCollider collider in spawnedObject.GameObject.GetComponents<BoxCollider>())
             {
                 Assert.IsFalse(collider.enabled);
             }
@@ -186,7 +186,7 @@ namespace VRBuilder.Core.Tests.Behaviors
             }
 
             bool wasDisabled = false;
-            foreach(BoxCollider collider in spawnedObject.GameObject.GetComponents<BoxCollider>())
+            foreach (BoxCollider collider in spawnedObject.GameObject.GetComponents<BoxCollider>())
             {
                 wasDisabled |= collider.enabled;
             }

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/SetValueBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/SetValueBehaviorTests.cs
@@ -34,10 +34,10 @@ namespace VRBuilder.Core.Tests.Behaviors
         {
             // Given the necessary parameters,
             IDataProperty<T> property = CreatePropertyObject();
-            string propertyName = property.SceneObject.UniqueName;
+            string guid = property.SceneObject.Guid.ToString();
 
             // When we create the behavior passing process objects by name,
-            SetValueBehavior<T> behavior = new SetValueBehavior<T>(propertyName, value);
+            SetValueBehavior<T> behavior = new SetValueBehavior<T>(guid, value);
 
             // Then all properties of the behavior are properly assigned.
             Assert.AreEqual(property, behavior.Data.DataProperty.Value);

--- a/Tests/Basic-Conditions-And-Behaviors/Behaviors/UnlockBehaviorTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Behaviors/UnlockBehaviorTests.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections;
+﻿using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Tests.Utils;
-using UnityEngine.TestTools;
-using UnityEngine;
-using NUnit.Framework;
 using Object = UnityEngine.Object;
 
 namespace VRBuilder.Core.Tests.Behaviors
@@ -21,7 +21,6 @@ namespace VRBuilder.Core.Tests.Behaviors
             // Given an game object with a changed unique name,
             GameObject gameObject = new GameObject("Test");
             ProcessSceneObject targetObject = gameObject.AddComponent<ProcessSceneObject>();
-            targetObject.ChangeUniqueName(targetName);
 
             // When we reference it by reference or unique name in the UnlockObjectBehavior,
 

--- a/Tests/Basic-Conditions-And-Behaviors/Builders/ProcessBuilderTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Builders/ProcessBuilderTests.cs
@@ -1,15 +1,15 @@
-using System;
 using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Conditions;
 using VRBuilder.Core.Properties;
-using VRBuilder.Tests.Builder;
 using VRBuilder.Core.SceneObjects;
+using VRBuilder.Tests.Builder;
 using VRBuilder.Tests.Utils;
-using UnityEngine;
-using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
 namespace VRBuilder.Core.Tests.Builder
@@ -176,13 +176,11 @@ namespace VRBuilder.Core.Tests.Builder
             ProcessSceneObject testCollider = colliderGo.AddComponent<ProcessSceneObject>();
             colliderGo.AddComponent<SphereCollider>().isTrigger = true;
             colliderGo.AddComponent<ColliderWithTriggerProperty>();
-            testCollider.ChangeUniqueName("Collider");
 
             GameObject putGo = new GameObject("Puttable");
             ProcessSceneObject testObjectToPut = putGo.AddComponent<ProcessSceneObject>();
             putGo.AddComponent<SphereCollider>().isTrigger = true;
             putGo.AddComponent<ColliderWithTriggerProperty>();
-            testObjectToPut.ChangeUniqueName("ToPut");
 
             LinearProcessBuilder builder = new LinearProcessBuilder("TestProcess")
                 .AddChapter(new LinearChapterBuilder("TestChapter")
@@ -210,7 +208,6 @@ namespace VRBuilder.Core.Tests.Builder
             // Given we have a process object and a builder for a process with a step with highlight that object
             GameObject go = new GameObject("Highlightable");
             EnableHighlightProperty highlightable = go.AddComponent<EnableHighlightProperty>();
-            highlightable.SceneObject.ChangeUniqueName("Highlightable");
 
             LinearProcessBuilder builder = new LinearProcessBuilder("TestProcess")
                 .AddChapter(new LinearChapterBuilder("TestChapter")

--- a/Tests/Basic-Conditions-And-Behaviors/Conditions/CompareValuesConditionTests.cs
+++ b/Tests/Basic-Conditions-And-Behaviors/Conditions/CompareValuesConditionTests.cs
@@ -43,8 +43,8 @@ namespace VRBuilder.Core.Tests.Conditions
             // Given the necessary parameters,
             IDataProperty<T> leftProperty = CreateValueProperty("Left Property Object", leftValue);
             IDataProperty<T> rightProperty = CreateValueProperty("Left Property Object", rightValue);
-            string leftPropertyName = leftProperty.SceneObject.UniqueName;
-            string rightPropertyName = rightProperty.SceneObject.UniqueName;
+            string leftPropertyName = leftProperty.SceneObject.Guid.ToString();
+            string rightPropertyName = rightProperty.SceneObject.Guid.ToString();
 
             // When we create the behavior passing process objects by name,
             CompareValuesCondition<T> condition = new CompareValuesCondition<T>(leftPropertyName, rightPropertyName, leftValue, rightValue, isLeftConst, isRightConst, operationType);

--- a/Tests/Basic-Interaction-Component/Builders/InteractionProcessBuilderTests.cs
+++ b/Tests/Basic-Interaction-Component/Builders/InteractionProcessBuilderTests.cs
@@ -1,21 +1,20 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Linq;
-using VRBuilder.BasicInteraction;
-using VRBuilder.Core.Properties;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.TestTools;
 using VRBuilder.BasicInteraction.Builders;
 using VRBuilder.BasicInteraction.Conditions;
 using VRBuilder.BasicInteraction.Properties;
 using VRBuilder.Core;
 using VRBuilder.Core.Configuration.Modes;
+using VRBuilder.Core.Properties;
 using VRBuilder.Core.SceneObjects;
 using VRBuilder.Tests.Builder;
 using VRBuilder.Tests.Utils;
-using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
-using UnityEngine.Events;
 
 namespace VRBuilder.Tests.Interaction
 {
@@ -32,11 +31,11 @@ namespace VRBuilder.Tests.Interaction
             public event EventHandler<EventArgs> ObjectUnsnapped;
 #pragma warning restore CS0067
 
-            
+
             public bool IsObjectSnapped { get; }
-            
+
             public ISnappableProperty SnappedObject { get; set; }
-            
+
             public GameObject SnapZoneObject { get; }
 
             public UnityEvent<SnapZonePropertyEventArgs> ObjectAttached => throw new NotImplementedException();
@@ -48,7 +47,7 @@ namespace VRBuilder.Tests.Interaction
                 throw new NotImplementedException();
             }
         }
-        
+
         private class DummySnappableProperty : ProcessSceneObjectProperty, ISnappableProperty
         {
 #pragma warning disable CS0067 // Disable "event is never used" warning.
@@ -59,9 +58,9 @@ namespace VRBuilder.Tests.Interaction
 #pragma warning restore CS0067
 
             public bool IsSnapped { get; }
-            
+
             public bool LockObjectOnSnap { get; }
-            
+
             public ISnapZoneProperty SnappedZone { get; set; }
 
             public UnityEvent<SnappablePropertyEventArgs> AttachedToSnapZone => throw new NotImplementedException();
@@ -97,12 +96,12 @@ namespace VRBuilder.Tests.Interaction
             {
                 throw new NotImplementedException();
             }
-            
+
 #pragma warning disable CS0067 // Disable "event is never used" warning.
             public event EventHandler<EventArgs> UsageStarted;
             public event EventHandler<EventArgs> UsageStopped;
 #pragma warning restore CS0067
-            
+
             public bool IsBeingUsed { get; }
 
             public UnityEvent<UsablePropertyEventArgs> UseStarted => throw new NotImplementedException();
@@ -126,12 +125,12 @@ namespace VRBuilder.Tests.Interaction
             {
                 throw new NotImplementedException();
             }
-            
+
 #pragma warning disable CS0067 // Disable "event is never used" warning.
             public event EventHandler<EventArgs> Touched;
             public event EventHandler<EventArgs> Untouched;
 #pragma warning restore CS0067
-            
+
             public bool IsBeingTouched { get; }
 
             public UnityEvent<TouchablePropertyEventArgs> TouchStarted => throw new NotImplementedException();
@@ -148,7 +147,7 @@ namespace VRBuilder.Tests.Interaction
                 throw new NotImplementedException();
             }
         }
-        
+
         [UnityTest]
         public IEnumerator BuildingSnapZonePutTest()
         {
@@ -156,12 +155,10 @@ namespace VRBuilder.Tests.Interaction
             GameObject snapZoneGo = new GameObject("SnapZone");
             ProcessSceneObject snapZone = snapZoneGo.AddComponent<ProcessSceneObject>();
             snapZoneGo.AddComponent<DummySnapZoneProperty>();
-            snapZone.ChangeUniqueName("SnapZone");
 
             GameObject putGo = new GameObject("Puttable");
             ProcessSceneObject objectToPut = putGo.AddComponent<ProcessSceneObject>();
             putGo.AddComponent<DummySnappableProperty>();
-            objectToPut.ChangeUniqueName("ToPut");
 
             LinearProcessBuilder builder = new LinearProcessBuilder("TestProcess")
                 .AddChapter(new LinearChapterBuilder("TestChapter")
@@ -183,7 +180,7 @@ namespace VRBuilder.Tests.Interaction
 
             return null;
         }
-        
+
         [UnityTest]
         public IEnumerator BuildingUseTest()
         {
@@ -191,7 +188,6 @@ namespace VRBuilder.Tests.Interaction
             GameObject usableGo = new GameObject("Usable");
             ProcessSceneObject usable = usableGo.AddComponent<ProcessSceneObject>();
             usableGo.AddComponent<DummyUsableProperty>();
-            usable.ChangeUniqueName("Usable");
 
             LinearProcessBuilder builder = new LinearProcessBuilder("TestProcess")
                 .AddChapter(new LinearChapterBuilder("TestChapter")
@@ -212,7 +208,7 @@ namespace VRBuilder.Tests.Interaction
 
             return null;
         }
-        
+
         [UnityTest]
         public IEnumerator BuildingTouchTest()
         {
@@ -220,7 +216,6 @@ namespace VRBuilder.Tests.Interaction
             GameObject touchableGo = new GameObject("Touchable");
             ProcessSceneObject touchable = touchableGo.AddComponent<ProcessSceneObject>();
             touchableGo.AddComponent<DummyTouchableProperty>();
-            touchable.ChangeUniqueName("Touchable");
 
             LinearProcessBuilder builder = new LinearProcessBuilder("TestProcess")
                 .AddChapter(new LinearChapterBuilder("TestChapter")


### PR DESCRIPTION
removed serialized uniqueName from ProcessSceneObject (and UserSceneObject) and replaced it with serialized string guid
- redirecting name UniqueName to guid
- obsoleted UniqueName, getName and similar methods

improved SceneObjectEditor 
- adding links to scripts (is discussable as only helpful for devs)
- made guid read only
- made override of guid for prefabs visibel (might be a good idea to split tagging and unique name component to have no need for cutom implementation of this)
- broke up big methods into smaller ones

