### PR TITLE
Delay call to create and save new Scene to avoid Assert

### DIFF
--- a/Source/Core/Editor/UI/Wizard/Setup/ProcessSceneSetupPage.cs
+++ b/Source/Core/Editor/UI/Wizard/Setup/ProcessSceneSetupPage.cs
@@ -69,7 +69,7 @@ namespace VRBuilder.Editor.UI.Wizard
             createNewProcess = GUILayout.Toggle(createNewProcess, "Create a new process", BuilderEditorStyles.Toggle);
             setupScene = GUILayout.Toggle(setupScene, "Setup the scene for VR Builder", BuilderEditorStyles.Toggle);
 
-            if(createNewProcess && !setupScene)
+            if (createNewProcess && !setupScene)
             {
                 EditorGUILayout.HelpBox("The new process will not work unless the scene is set up for VR Builder. Proceed only if you mean to add a new process " +
                     "to an already configured scene.", MessageType.Warning);
@@ -168,23 +168,27 @@ namespace VRBuilder.Editor.UI.Wizard
                 return;
             }
 
-            if (createNewProcess && useCurrentScene == false)
+            // Delay call to avoid Assertion failed on expression: 'GetApplication().MayUpdate()'
+            EditorApplication.delayCall += () =>
             {
-                SceneSetupUtils.CreateNewScene(processName);
-            }
+                if (createNewProcess && useCurrentScene == false)
+                {
+                    SceneSetupUtils.CreateNewScene(processName);
+                }
 
-            if(setupScene)
-            {
-                ProcessSceneSetup.Run(configurations[selectedIndex]);
-            }
+                if (setupScene)
+                {
+                    ProcessSceneSetup.Run(configurations[selectedIndex]);
+                }
 
-            if (createNewProcess)
-            {
-                SceneSetupUtils.SetupProcess(processName);
-            }
+                if (createNewProcess)
+                {
+                    SceneSetupUtils.SetupProcess(processName);
+                }
 
-            lastCreatedProcess = processName;
-            EditorWindow.FocusWindowIfItsOpen<WizardWindow>();
+                lastCreatedProcess = processName;
+                EditorWindow.FocusWindowIfItsOpen<WizardWindow>();
+            };
         }
     }
 }


### PR DESCRIPTION
There is some interference with other Editor code running I delayed the creating and saving of the new scene.

The error message "Assertion failed on expression: 'GetApplication().MayUpdate()'", typically indicates an issue with the way the Unity Editor's scene management functions are being called. This can happen due to trying to manipulate scenes in a way that's not allowed in the current state of the Unity Editor.