### PR TITLE
Restored dropdown drawer for unlock objects tab

### DIFF
--- a/Source/Core/Editor/UI/Drawers/LockableObjectsDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/LockableObjectsDrawer.cs
@@ -53,7 +53,11 @@ namespace VRBuilder.Editor.UI.Drawers
             currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
 
             EditorGUI.BeginDisabledGroup(selectedTag.IsEmpty() || lockableCollection.TagsToUnlock.Contains(selectedTag.Guid));
-            if (GUI.Button(currentPosition, "Add tag to unlock list"))
+
+            Rect guiRect = currentPosition;
+            guiRect.y += currentPosition.height;
+            guiRect.height = EditorDrawingHelper.SingleLineHeight;
+            if (GUI.Button(guiRect, "Add tag to unlock list"))
             {
                 lockableCollection.AddTag(selectedTag.Guid);
 
@@ -63,15 +67,15 @@ namespace VRBuilder.Editor.UI.Drawers
                 }
             }
 
-            currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+            guiRect.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
             EditorGUI.EndDisabledGroup();
 
-            EditorGUI.LabelField(currentPosition, "Select the properties to attempt to unlock for each tag:");
-            currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+            EditorGUI.LabelField(guiRect, "Select the properties to attempt to unlock for each tag:");
+            guiRect.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
 
             foreach (Guid guid in new List<Guid>(lockableCollection.TagsToUnlock))
             {
-                GUILayout.BeginArea(currentPosition);
+                GUILayout.BeginArea(guiRect);
                 GUILayout.BeginHorizontal();
 
                 if (foldoutStatus.ContainsKey(guid) == false)
@@ -87,7 +91,7 @@ namespace VRBuilder.Editor.UI.Drawers
                     break;
                 }
 
-                currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+                guiRect.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
                 GUILayout.EndHorizontal();
                 GUILayout.EndArea();
 
@@ -95,13 +99,13 @@ namespace VRBuilder.Editor.UI.Drawers
                 {
                     foreach (Type type in PropertyReflectionHelper.ExtractFittingPropertyType<LockableProperty>(typeof(LockableProperty)))
                     {
-                        Rect objectPosition = currentPosition;
+                        Rect objectPosition = guiRect;
                         objectPosition.x += EditorDrawingHelper.IndentationWidth * 2f;
                         objectPosition.width -= EditorDrawingHelper.IndentationWidth * 2f;
 
                         bool isFlagged = lockableCollection.IsPropertyEnabledForTag(guid, type);
 
-                        if (EditorGUI.Toggle(currentPosition, isFlagged) != isFlagged)
+                        if (EditorGUI.Toggle(guiRect, isFlagged) != isFlagged)
                         {
                             if (isFlagged)
                             {
@@ -117,11 +121,12 @@ namespace VRBuilder.Editor.UI.Drawers
 
                         EditorGUI.LabelField(objectPosition, type.Name);
 
-                        currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+                        guiRect.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
                     }
                 }
             }
 
+            currentPosition = guiRect;
             // EditorDrawingHelper.HeaderLineHeight - 24f is just the magic number to make it properly fit...
             return new Rect(rect.x, rect.y, rect.width, currentPosition.y - EditorDrawingHelper.HeaderLineHeight - 24f);
         }

--- a/Source/Core/Editor/UI/Drawers/LockableObjectsDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/LockableObjectsDrawer.cs
@@ -49,8 +49,7 @@ namespace VRBuilder.Editor.UI.Drawers
 
             currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
 
-            currentPosition = DrawerLocator.GetDrawerForValue(selectedTag, typeof(SceneObjectTagBase)).Draw(currentPosition, selectedTag, (value) => { selectedTag = value as SceneObjectTagBase; }, "Select tag to unlock:"); ;
-            currentPosition.y += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+            currentPosition = new UserTagDropdownDrawer().Draw(currentPosition, selectedTag, (value) => { selectedTag = value as SceneObjectTagBase; }, "Select tag to unlock:");
 
             EditorGUI.BeginDisabledGroup(selectedTag.IsEmpty() || lockableCollection.TagsToUnlock.Contains(selectedTag.Guid));
 

--- a/Source/Core/Editor/UI/Drawers/UserTagDropdownDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/UserTagDropdownDrawer.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using VRBuilder.Core.Configuration;
+using VRBuilder.Core.Properties;
+using VRBuilder.Core.SceneObjects;
+using VRBuilder.Core.Settings;
+using VRBuilder.Editor.UndoRedo;
+
+namespace VRBuilder.Editor.UI.Drawers
+{
+    /// <summary>
+    /// Drawer for <see cref="SceneObjectTagBase"/>.
+    /// </summary>
+    public class UserTagDropdownDrawer : AbstractDrawer
+    {
+        private const string noComponentSelected = "<none>";
+        protected bool isUndoOperation;
+
+        public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
+        {
+            SceneObjectTagBase sceneObjectTag = (SceneObjectTagBase)currentValue;
+            Guid oldGuid = sceneObjectTag.Guid;
+            SceneObjectTags.Tag[] tags = SceneObjectTags.Instance.Tags.ToArray();
+            List<string> labels = tags.Select(tag => tag.Label).ToList();
+            SceneObjectTags.Tag currentTag = tags.FirstOrDefault(tag => tag.Guid == oldGuid);
+            Rect guiLineRect = rect;
+
+            if (currentTag != null)
+            {
+                foreach (ISceneObject sceneObject in RuntimeConfigurator.Configuration.SceneObjectRegistry.GetByTag(currentTag.Guid))
+                {
+                    CheckForMisconfigurationIssues(sceneObject.GameObject, sceneObjectTag.GetReferenceType(), ref rect, ref guiLineRect);
+                }
+            }
+
+            EditorGUI.BeginDisabledGroup(tags.Length == 0);
+
+            int selectedTagIndex = Array.IndexOf(tags, currentTag);
+            bool isTagInvalid = false;
+
+            if (selectedTagIndex == -1)
+            {
+                selectedTagIndex = 0;
+                labels.Insert(0, noComponentSelected);
+                isTagInvalid = true;
+            }
+
+            selectedTagIndex = EditorGUI.Popup(guiLineRect, label.text, selectedTagIndex, labels.ToArray());
+            EditorGUI.EndDisabledGroup();
+
+            if (isTagInvalid && selectedTagIndex == 0)
+            {
+                return rect;
+            }
+            else if (isTagInvalid)
+            {
+                selectedTagIndex--;
+            }
+
+            Guid newGuid = tags[selectedTagIndex].Guid;
+
+            if (oldGuid != newGuid)
+            {
+                ChangeValue(
+                () =>
+                {
+                    sceneObjectTag.Guids = new List<Guid> { newGuid };
+                    return sceneObjectTag;
+                },
+                () =>
+                {
+                    sceneObjectTag.Guids = new List<Guid> { oldGuid };
+                    return sceneObjectTag;
+                },
+                changeValueCallback);
+            }
+
+            return rect;
+        }
+
+        protected void CheckForMisconfigurationIssues(GameObject selectedSceneObject, Type valueType, ref Rect originalRect, ref Rect guiLineRect)
+        {
+            if (selectedSceneObject != null && selectedSceneObject.GetComponent(valueType) == null)
+            {
+                string warning = $"{selectedSceneObject.name} is not configured as {valueType.Name}";
+                const string button = "Fix it";
+                EditorGUI.HelpBox(guiLineRect, warning, MessageType.Warning);
+                guiLineRect = AddNewRectLine(ref originalRect);
+
+                if (GUI.Button(guiLineRect, button))
+                {
+                    // Only relevant for Undoing a Process Property.
+                    bool isAlreadySceneObject = selectedSceneObject.GetComponent<ProcessSceneObject>() != null && typeof(ISceneObjectProperty).IsAssignableFrom(valueType);
+                    Component[] alreadyAttachedProperties = selectedSceneObject.GetComponents(typeof(Component));
+
+                    RevertableChangesHandler.Do(
+                        new ProcessCommand(
+                            () => SceneObjectAutomaticSetup(selectedSceneObject, valueType),
+                            () => UndoSceneObjectAutomaticSetup(selectedSceneObject, valueType, isAlreadySceneObject, alreadyAttachedProperties)));
+                }
+
+                guiLineRect = AddNewRectLine(ref originalRect);
+            }
+        }
+
+        protected Rect AddNewRectLine(ref Rect currentRect)
+        {
+            Rect newRectLine = currentRect;
+            newRectLine.height = EditorDrawingHelper.SingleLineHeight;
+            newRectLine.y += currentRect.height + EditorDrawingHelper.VerticalSpacing;
+
+            currentRect.height += EditorDrawingHelper.SingleLineHeight + EditorDrawingHelper.VerticalSpacing;
+            return newRectLine;
+        }
+
+        protected void SceneObjectAutomaticSetup(GameObject selectedSceneObject, Type valueType)
+        {
+            ISceneObject sceneObject = selectedSceneObject.GetComponent<ProcessSceneObject>() ?? selectedSceneObject.AddComponent<ProcessSceneObject>();
+
+            if (RuntimeConfigurator.Configuration.SceneObjectRegistry.ContainsGuid(sceneObject.Guid) == false)
+            {
+                // Sets a UniqueName and then registers it.
+                sceneObject.SetSuitableName();
+            }
+
+            if (typeof(ISceneObjectProperty).IsAssignableFrom(valueType))
+            {
+                sceneObject.AddProcessProperty(valueType);
+            }
+
+            isUndoOperation = true;
+        }
+
+        private void UndoSceneObjectAutomaticSetup(GameObject selectedSceneObject, Type valueType, bool hadProcessComponent, Component[] alreadyAttachedProperties)
+        {
+            ISceneObject sceneObject = selectedSceneObject.GetComponent<ProcessSceneObject>();
+
+            if (typeof(ISceneObjectProperty).IsAssignableFrom(valueType))
+            {
+                sceneObject.RemoveProcessProperty(valueType, true, alreadyAttachedProperties);
+            }
+
+            if (hadProcessComponent == false)
+            {
+                UnityEngine.Object.DestroyImmediate((ProcessSceneObject)sceneObject);
+            }
+
+            isUndoOperation = true;
+        }
+    }
+}

--- a/Source/Core/Editor/UI/Drawers/UserTagDropdownDrawer.cs.meta
+++ b/Source/Core/Editor/UI/Drawers/UserTagDropdownDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9804bdf8e5d399240bec484be0b9eb76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As the new reference drawer does not fit the "Unlock objects" tab, I restored the old dropdown drawer for tags in order to make that tab usable.