### PR TITLE
Assorted fixes

### DIFF
--- a/Source/Basic-Interaction-Component/Runtime/Validation/HasGuidValidation.cs
+++ b/Source/Basic-Interaction-Component/Runtime/Validation/HasGuidValidation.cs
@@ -61,11 +61,6 @@ namespace VRBuilder.BasicInteraction.Validation
                 return false;
             }
 
-            if (Guids.Count() == 0)
-            {
-                return true;
-            }
-
             return Guids.Any(guid => processSceneObject.Guid == guid || processSceneObject.HasGuid(guid));
         }
     }

--- a/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
@@ -160,6 +160,7 @@ namespace VRBuilder.Editor.UI
                 SceneObjectGroups.SceneObjectGroup newGroup = CreateGroup(newGroupTextField.text, groupContainers);
                 AddGroupElement(groupListContainer, newGroup);
                 newGroupTextField.value = "";
+                EditorUtility.SetDirty(SceneObjectGroups.Instance);
             };
         }
 

--- a/Source/Core/Editor/UI/Wizard/WizardWindow.cs
+++ b/Source/Core/Editor/UI/Wizard/WizardWindow.cs
@@ -75,7 +75,18 @@ namespace VRBuilder.Editor.UI.Wizard
                 entries.Add(new WizardNavigation.Entry(page.Name, entries.Count));
             }
 
-            entries[selectedPage].Selected = true;
+            if (selectedPage < entries.Count)
+            {
+                entries[selectedPage].Selected = true;
+            }
+            else
+            {
+                // The wizard has somehow been invalidated, close the window and recreate it.
+                Close();
+                ProjectSetupWizard.Show();
+                return null;
+            }
+
             return new WizardNavigation(entries);
         }
 
@@ -84,6 +95,11 @@ namespace VRBuilder.Editor.UI.Wizard
             if (navigation == null)
             {
                 navigation = CreateNavigation();
+            }
+
+            if (navigation == null)
+            {
+                return;
             }
 
             navigation.Draw(GetNavigationRect());


### PR DESCRIPTION
- An empty HasGuidValidation accepts zero objects instead of every object
- Groups created from PSOs are persisted correctly
- Fixed potential exception when automatically opening the project wizard after importing