### PR TITLE
Improve process window scene open close behavior

### DIFF
--- a/Source/Core/Editor/GlobalEditorHandler.cs
+++ b/Source/Core/Editor/GlobalEditorHandler.cs
@@ -186,9 +186,18 @@ namespace VRBuilder.Editor
             strategy.HandleExitingPlayMode();
         }
 
+
+        /// <summary>
+        /// Sets the current process when a scene is opened.
+        /// </summary>
+        /// <param name="scene">The opened scene.</param>
+        /// <param name="mode">The mode in which the scene was opened.</param>
+        /// <remarks>
+        /// When having two scenes containing a RuntimeConfigurator, RuntimeConfigurator from the scene which was oped first will be used.
+        /// </remarks>
         private static void OnSceneOpened(Scene scene, OpenSceneMode mode)
         {
-            if (RuntimeConfigurator.Exists == false)
+            if (RuntimeConfigurator.IsExisting(forceNewLookup: true) == false)
             {
                 SetCurrentProcess(string.Empty);
                 return;
@@ -203,6 +212,7 @@ namespace VRBuilder.Editor
             }
 
             string processName = System.IO.Path.GetFileNameWithoutExtension(processPath);
+
             SetCurrentProcess(processName);
         }
     }

--- a/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
+++ b/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
@@ -285,7 +285,6 @@ namespace VRBuilder.Editor
                 Debug.LogError($"Process {process.Data.Name} is stored in an invalid path.");
             }
 
-            Debug.Log($"Process {process.Data.Name} was renamed to {newName}.");
             RuntimeConfigurator.Instance.SetSelectedProcess(streamingAssetPath);
         }
 

--- a/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
+++ b/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
@@ -218,7 +218,9 @@ namespace VRBuilder.Editor
 
         /// <summary>
         /// Loads the process with the given <paramref name="processName"/> from the file system and converts it into the <seealso cref="IProcess"/> instance.
+        /// Sets up a file system watcher to monitor changes in the directory of the process.
         /// </summary>
+        /// <param name="processName">The name of the process to load or <seealso cref="string.Empty"/> if the scene dos not contain a process.</param>
         internal static IProcess Load(string processName)
         {
             if (ProcessAssetUtils.DoesProcessAssetExist(processName))
@@ -243,6 +245,10 @@ namespace VRBuilder.Editor
                     Debug.LogError($"Failed to load the process '{processName}' from '{processAssetPath}' because of: \n{ex.Message}");
                     Debug.LogError(ex);
                 }
+            }
+            else
+            {
+                DisposeWatcher();
             }
             return null;
         }
@@ -279,6 +285,7 @@ namespace VRBuilder.Editor
                 Debug.LogError($"Process {process.Data.Name} is stored in an invalid path.");
             }
 
+            Debug.Log($"Process {process.Data.Name} was renamed to {newName}.");
             RuntimeConfigurator.Instance.SetSelectedProcess(streamingAssetPath);
         }
 
@@ -337,18 +344,41 @@ namespace VRBuilder.Editor
             return additionalData;
         }
 
+
+        /// <summary>
+        /// Sets up a file system watcher to monitor changes to all files of type <see cref="EditorConfigurator.Instance.Serializer.FileFormat"/> 
+        /// in the specified process asset directory. If the path changes, we dispose the existing watcher and create a new one.
+        /// </summary>
+        /// <param name="processName">The name of the new process to be watched.</param>
+        /// <remarks>
+        /// We need to dispose the watcher and create a new one if the path changes. If we don't do this, the watcher will listen to the old path.
+        /// This seems to be a bug in the Unity implementation of FileSystemWatcher (Tested with Unity 2022.3.25).
+        /// </remarks>
         private static void SetupWatcher(string processName)
         {
-            if (watcher == null)
+
+            if (watcher != null)
             {
-                watcher = new FileSystemWatcher();
-                watcher.Changed += OnFileChanged;
+                if (watcher.Path == ProcessAssetUtils.GetProcessAssetDirectory(processName))
+                {
+                    return;
+                }
+                DisposeWatcher();
             }
 
+            watcher = new FileSystemWatcher();
+            watcher.Changed += OnFileChanged;
             watcher.Path = ProcessAssetUtils.GetProcessAssetDirectory(processName);
             watcher.Filter = $"*.{EditorConfigurator.Instance.Serializer.FileFormat}";
+        }
 
-            watcher.EnableRaisingEvents = true;
+        private static void DisposeWatcher()
+        {
+            if (watcher != null)
+            {
+                watcher.Dispose();
+                watcher = null;
+            }
         }
 
         private static void OnFileChanged(object sender, FileSystemEventArgs e)
@@ -361,6 +391,8 @@ namespace VRBuilder.Editor
                 }
                 return;
             }
+
+            var name = ProcessAssetUtils.GetProcessNameFromPath(e.FullPath);
 
             ExternalFileChange?.Invoke(null, EventArgs.Empty);
         }

--- a/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
+++ b/Source/Core/Editor/ProcessAssets/ProcessAssetManager.cs
@@ -391,7 +391,6 @@ namespace VRBuilder.Editor
                 return;
             }
 
-            var name = ProcessAssetUtils.GetProcessNameFromPath(e.FullPath);
 
             ExternalFileChange?.Invoke(null, EventArgs.Empty);
         }

--- a/Source/Core/Editor/Setup/SceneSetupUtils.cs
+++ b/Source/Core/Editor/Setup/SceneSetupUtils.cs
@@ -58,7 +58,7 @@ namespace VRBuilder.Editor.Setup
             {
                 if (ProcessAssetUtils.DoesProcessAssetExist(processName))
                 {
-                     ProcessAssetManager.Load(processName);
+                    ProcessAssetManager.Load(processName);
                 }
                 else
                 {

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphView.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphView.cs
@@ -1,8 +1,8 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using UnityEditor;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
@@ -12,6 +12,7 @@ using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Serialization;
 using VRBuilder.Editor.Configuration;
 using VRBuilder.Editor.UndoRedo;
+
 using static UnityEditor.TypeCache;
 
 namespace VRBuilder.Editor.UI.Graphics
@@ -119,6 +120,12 @@ namespace VRBuilder.Editor.UI.Graphics
         /// <inheritdoc/>
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
+            if (GlobalEditorHandler.GetCurrentProcess() == null)
+            {
+                // No VR Builder scene is currently open
+                return;
+            }
+
             foreach (IStepNodeInstantiator instantiator in instantiators.Where(i => i.IsInNodeMenu).OrderBy(i => i.Priority))
             {
                 evt.menu.AppendAction($"New/{instantiator.Name}", (status) =>

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -140,10 +140,10 @@ namespace VRBuilder.Editor.UI.Graphics
 
             currentProcess = process;
 
+            ResetGraphView();
             if (currentProcess == null)
             {
-                // Reset the window to no process existing
-                ResetGraphView();
+                graphView.Add(CreateMissingProcessWarningLabel());
                 return;
             }
 
@@ -156,6 +156,24 @@ namespace VRBuilder.Editor.UI.Graphics
             };
 
             SetChapter(currentProcess.Data.FirstChapter);
+        }
+
+        private static Label CreateMissingProcessWarningLabel()
+        {
+            Label warningLabel;
+            warningLabel = new Label("There is no process loaded.\n Please open a VR Builder compatible scene.")
+            {
+                style =
+                    {
+                        //color = Color.red,
+                        unityTextAlign = TextAnchor.MiddleCenter,
+                        fontSize = 18,
+                        unityFontStyleAndWeight = FontStyle.Bold,
+                        top = Length.Percent(40),
+                        left = Length.Percent(10)
+                    }
+            };
+            return warningLabel;
         }
 
         /// <summary>

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.Localization.Plugins.XLIFF.V12;
 using UnityEngine;
 using UnityEngine.UIElements;
 using VRBuilder.Core;
@@ -144,16 +145,18 @@ namespace VRBuilder.Editor.UI.Graphics
 
             currentProcess = process;
 
-
+            // If the process is null, remove the graph view and chapter vie and display a warning label.
             if (currentProcess == null)
             {
+                chapterViewContainer.RemoveFromHierarchy();
                 ResetGraphView();
                 graphView.Add(noProcessWarningLabel);
                 return;
             }
             else if (graphView.Children().Contains(noProcessWarningLabel))
             {
-                graphView.Remove(noProcessWarningLabel);
+                noProcessWarningLabel.RemoveFromHierarchy();
+                rootVisualElement.Add(chapterViewContainer);
             }
 
             chapterMenu.Initialise(currentProcess, this);
@@ -189,10 +192,9 @@ namespace VRBuilder.Editor.UI.Graphics
         /// </summary>
         internal void ResetGraphView()
         {
-            chapterMenu?.Reset();
             graphView?.Clear();
-            chapterViewContainer?.Clear();
-            chapterHierarchy?.Clear();
+            graphView?.RemoveFromHierarchy();
+            graphView = null;
             graphView = ConstructGraphView();
         }
 

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -145,7 +145,7 @@ namespace VRBuilder.Editor.UI.Graphics
 
             currentProcess = process;
 
-            // If the process is null, remove the graph view and chapter vie and display a warning label.
+            // If the process is null, remove the graph view and chapter view and display a warning label.
             if (currentProcess == null)
             {
                 chapterViewContainer.RemoveFromHierarchy();
@@ -158,7 +158,6 @@ namespace VRBuilder.Editor.UI.Graphics
                 noProcessWarning.style.display = DisplayStyle.None;
                 rootVisualElement.Add(chapterViewContainer);
                 graphView = ConstructGraphView();
-
             }
 
             chapterMenu.Initialise(currentProcess, this);
@@ -177,6 +176,8 @@ namespace VRBuilder.Editor.UI.Graphics
             EditorUtils.CheckVisualTreeAssets(nameof(ProcessGraphViewWindow), new List<VisualTreeAsset>() { noProcessWarningAsset });
             noProcessWarning = noProcessWarningAsset.CloneTree();
             noProcessWarning.style.display = DisplayStyle.None;
+            // Ensure it takes full space making it centered
+            noProcessWarning.style.flexGrow = 1;
             rootVisualElement.Add(noProcessWarning);
             return noProcessWarning;
         }

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -174,16 +174,10 @@ namespace VRBuilder.Editor.UI.Graphics
 
         private VisualElement CreateMissingProcessWarning()
         {
-            if (noProcessWarningAsset != null)
-            {
-                noProcessWarning = noProcessWarningAsset.CloneTree();
-                noProcessWarning.style.display = DisplayStyle.None;
-                rootVisualElement.Add(noProcessWarning);
-            }
-            else
-            {
-                Debug.LogError("No process warning UXML missing.");
-            }
+            EditorUtils.CheckVisualTreeAssets(nameof(ProcessGraphViewWindow), new List<VisualTreeAsset>() { noProcessWarningAsset });
+            noProcessWarning = noProcessWarningAsset.CloneTree();
+            noProcessWarning.style.display = DisplayStyle.None;
+            rootVisualElement.Add(noProcessWarning);
             return noProcessWarning;
         }
 

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -142,6 +142,8 @@ namespace VRBuilder.Editor.UI.Graphics
 
             if (currentProcess == null)
             {
+                // Reset the window to no process existing
+                ResetGraphView();
                 return;
             }
 
@@ -154,6 +156,18 @@ namespace VRBuilder.Editor.UI.Graphics
             };
 
             SetChapter(currentProcess.Data.FirstChapter);
+        }
+
+        /// <summary>
+        /// Resets the process graph window to an empty state.
+        /// </summary>
+        internal void ResetGraphView()
+        {
+            chapterMenu?.Reset();
+            graphView?.Clear();
+            chapterViewContainer?.Clear();
+            chapterHierarchy?.Clear();
+            graphView = ConstructGraphView();
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs
@@ -39,6 +39,8 @@ namespace VRBuilder.Editor.UI.Graphics
         private IMGUIContainer chapterViewContainer;
         private IProcess currentProcess;
         private IChapter currentChapter;
+
+        private Label noProcessWarningLabel;
         private bool isFileChanged;
         private object lockObject = new object();
 
@@ -61,6 +63,8 @@ namespace VRBuilder.Editor.UI.Graphics
 
             graphView = ConstructGraphView();
             chapterHierarchy = ConstructChapterHierarchy();
+
+            noProcessWarningLabel = CreateMissingProcessWarningLabel();
 
             ProcessAssetManager.ExternalFileChange += OnExternalFileChange;
 
@@ -140,11 +144,16 @@ namespace VRBuilder.Editor.UI.Graphics
 
             currentProcess = process;
 
-            ResetGraphView();
+
             if (currentProcess == null)
             {
-                graphView.Add(CreateMissingProcessWarningLabel());
+                ResetGraphView();
+                graphView.Add(noProcessWarningLabel);
                 return;
+            }
+            else if (graphView.Children().Contains(noProcessWarningLabel))
+            {
+                graphView.Remove(noProcessWarningLabel);
             }
 
             chapterMenu.Initialise(currentProcess, this);
@@ -160,8 +169,7 @@ namespace VRBuilder.Editor.UI.Graphics
 
         private static Label CreateMissingProcessWarningLabel()
         {
-            Label warningLabel;
-            warningLabel = new Label("There is no process loaded.\n Please open a VR Builder compatible scene.")
+            Label noProcessWarningLabel = new Label("There is no process loaded.\n Please open a VR Builder compatible scene.")
             {
                 style =
                     {
@@ -173,7 +181,7 @@ namespace VRBuilder.Editor.UI.Graphics
                         left = Length.Percent(10)
                     }
             };
-            return warningLabel;
+            return noProcessWarningLabel;
         }
 
         /// <summary>

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs.meta
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs.meta
@@ -6,7 +6,7 @@ MonoImporter:
   defaultReferences:
   - m_ViewDataDictionary: {instanceID: 0}
   - chapterMenu: {instanceID: 0}
-  - noProcessLoadedWarning: {fileID: 9197481963319205126, guid: 739d556a3f7ffcc4390448540eb57d3a, type: 3}
+  - noProcessWarningAsset: {fileID: 9197481963319205126, guid: 9d9ddbf887ab99a478141d43e1cfe76d, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs.meta
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphViewWindow.cs.meta
@@ -3,7 +3,10 @@ guid: adf947b32cd88ee49959a367becce140
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - m_ViewDataDictionary: {instanceID: 0}
+  - chapterMenu: {instanceID: 0}
+  - noProcessLoadedWarning: {fileID: 9197481963319205126, guid: 739d556a3f7ffcc4390448540eb57d3a, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Source/Core/Editor/UI/Menu/OpenProcessMenuEntry.cs
+++ b/Source/Core/Editor/UI/Menu/OpenProcessMenuEntry.cs
@@ -12,7 +12,7 @@ namespace VRBuilder.Editor.BuilderMenu
         /// <summary>
         /// Open the Workflow Editor window.
         /// </summary>
-        [MenuItem("Tools/VR Builder/Process Editor", false, 2)]
+        [MenuItem("Tools/VR Builder/Open Process Editor", false, 2)]
         [MenuItem("Window/VR Builder/Process Editor", false, 100)]
         private static void OpenWorkflowEditor()
         {

--- a/Source/Core/Editor/UI/Views/NoProcessWarning.uxml
+++ b/Source/Core/Editor/UI/Views/NoProcessWarning.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <ui:VisualElement name="NoProcessWarning" style="top: auto;">
+    <ui:VisualElement name="NoProcessWarning" style="justify-content: center; align-items: center; width: 100%; height: 80%;">
         <ui:Label text="There is no process loaded.\nPlease open a VR Builder compatible scene." parse-escape-sequences="true" display-tooltip-when-elided="true" style="-unity-font-style: bold; font-size: 18px; -unity-text-align: middle-center;" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Source/Core/Editor/UI/Views/NoProcessWarning.uxml
+++ b/Source/Core/Editor/UI/Views/NoProcessWarning.uxml
@@ -1,0 +1,5 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <ui:VisualElement name="NoProcessWarning" style="top: auto;">
+        <ui:Label text="There is no process loaded.\nPlease open a VR Builder compatible scene." parse-escape-sequences="true" display-tooltip-when-elided="true" style="-unity-font-style: bold; font-size: 18px; -unity-text-align: middle-center;" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Source/Core/Editor/UI/Views/NoProcessWarning.uxml.meta
+++ b/Source/Core/Editor/UI/Views/NoProcessWarning.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9d9ddbf887ab99a478141d43e1cfe76d
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Source/Core/Editor/UI/Windows/ProcessMenuView.cs
+++ b/Source/Core/Editor/UI/Windows/ProcessMenuView.cs
@@ -1,18 +1,16 @@
 // Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2024 MindPort GmbH
-
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
 using VRBuilder.Core;
-using VRBuilder.Core.Validation;
+using VRBuilder.Core.Behaviors;
 using VRBuilder.Editor.Configuration;
 using VRBuilder.Editor.ProcessValidation;
 using VRBuilder.Editor.UndoRedo;
-using UnityEditor;
-using UnityEngine;
-using System.Collections.Generic;
-using System.Linq;
-using VRBuilder.Core.Behaviors;
 
 namespace VRBuilder.Editor.UI.Windows
 {
@@ -138,6 +136,11 @@ namespace VRBuilder.Editor.UI.Windows
             }
         }
 
+        public void Reset()
+        {
+            Process = null;
+        }
+
         private void LoadIcons()
         {
             deleteIcon = new EditorIcon("icon_delete");
@@ -154,6 +157,11 @@ namespace VRBuilder.Editor.UI.Windows
         /// </summary>
         public void Draw()
         {
+            if (Process == null)
+            {
+                return;
+            }
+
             IsExtended = isExtended;
             GUILayout.BeginArea(new Rect(0f, 0f, IsExtended ? ExtendedMenuWidth : MinimizedMenuWidth, ParentWindow.position.height));
             {
@@ -311,7 +319,7 @@ namespace VRBuilder.Editor.UI.Windows
             }
             GUILayout.EndHorizontal();
 
-            if(isActiveChapter)
+            if (isActiveChapter)
             {
                 EditorGUILayout.BeginHorizontal();
                 GUILayout.Space(16);
@@ -327,7 +335,7 @@ namespace VRBuilder.Editor.UI.Windows
                     if (incomingConnections.Count > 0)
                     {
                         GUILayout.Label("\tIncoming:");
-                        foreach (Guid connectedChapter in incomingConnections.Keys.OrderBy(key => Process.Data.Chapters.IndexOf(Process.Data.Chapters.FirstOrDefault(chapter => chapter.ChapterMetadata.Guid == key)))) 
+                        foreach (Guid connectedChapter in incomingConnections.Keys.OrderBy(key => Process.Data.Chapters.IndexOf(Process.Data.Chapters.FirstOrDefault(chapter => chapter.ChapterMetadata.Guid == key))))
                         {
                             string chapterName = "<i>Previous Chapter</i>";
 
@@ -350,7 +358,7 @@ namespace VRBuilder.Editor.UI.Windows
                             string chapterName = "<i>Next Chapter</i>";
 
                             IChapter chapter = Process.Data.Chapters.FirstOrDefault(chapter => chapter.ChapterMetadata.Guid == connectedChapter);
-                            if(chapter != null)
+                            if (chapter != null)
                             {
                                 chapterName = chapter.Data.Name;
                             }
@@ -359,7 +367,7 @@ namespace VRBuilder.Editor.UI.Windows
                         }
                     }
                 }
-            }            
+            }
         }
 
         private void DrawExtendToggle()
@@ -622,28 +630,28 @@ namespace VRBuilder.Editor.UI.Windows
             }
             IChapterData chapterData = chapter.Data;
 
-            if(chapterData.FirstStep == null)
+            if (chapterData.FirstStep == null)
             {
                 connections.Add(Guid.Empty, 1);
             }
 
             IEnumerable<IStep> outgoingSteps = chapterData.Steps.Where(step => step.Data.Transitions.Data.Transitions.Any(transition => transition.Data.TargetStep == null));
 
-            foreach(IStep step in outgoingSteps)
+            foreach (IStep step in outgoingSteps)
             {
                 Guid nextChapter = Guid.Empty;
                 GoToChapterBehavior goToChapter = step.Data.Behaviors.Data.Behaviors.FirstOrDefault(behavior => behavior is GoToChapterBehavior) as GoToChapterBehavior;
 
-                if(goToChapter != null)
+                if (goToChapter != null)
                 {
                     IChapter targetChapter = Process.Data.Chapters.FirstOrDefault(chapter => chapter.ChapterMetadata.Guid == goToChapter.Data.ChapterGuid);
-                    if(targetChapter != null)
+                    if (targetChapter != null)
                     {
                         nextChapter = targetChapter.ChapterMetadata.Guid;
                     }
                 }
 
-                if(connections.ContainsKey(nextChapter))
+                if (connections.ContainsKey(nextChapter))
                 {
                     connections[nextChapter]++;
                 }
@@ -665,7 +673,7 @@ namespace VRBuilder.Editor.UI.Windows
                 return connections;
             }
 
-            foreach(IChapter chapter in Process.Data.Chapters)
+            foreach (IChapter chapter in Process.Data.Chapters)
             {
                 if (Process.Data.Chapters.IndexOf(chapter) == chapterIndex - 1 && chapter.Data.FirstStep == null)
                 {
@@ -674,15 +682,15 @@ namespace VRBuilder.Editor.UI.Windows
 
                 IEnumerable<IStep> outgoingSteps = chapter.Data.Steps.Where(step => step.Data.Transitions.Data.Transitions.Any(transition => transition.Data.TargetStep == null));
 
-                foreach(IStep step in outgoingSteps)
+                foreach (IStep step in outgoingSteps)
                 {
                     GoToChapterBehavior goToChapter = step.Data.Behaviors.Data.Behaviors.FirstOrDefault(behavior => behavior is GoToChapterBehavior) as GoToChapterBehavior;
 
                     if (goToChapter != null)
                     {
-                        if(goToChapter.Data.ChapterGuid == currentChapter.ChapterMetadata.Guid)
+                        if (goToChapter.Data.ChapterGuid == currentChapter.ChapterMetadata.Guid)
                         {
-                            if(connections.ContainsKey(chapter.ChapterMetadata.Guid))
+                            if (connections.ContainsKey(chapter.ChapterMetadata.Guid))
                             {
                                 connections[chapter.ChapterMetadata.Guid]++;
                             }
@@ -692,7 +700,7 @@ namespace VRBuilder.Editor.UI.Windows
                             }
                         }
                     }
-                    else if(Process.Data.Chapters.IndexOf(chapter) == chapterIndex - 1)
+                    else if (Process.Data.Chapters.IndexOf(chapter) == chapterIndex - 1)
                     {
                         if (connections.ContainsKey(Guid.Empty))
                         {

--- a/Source/Core/Editor/UI/Windows/ProcessMenuView.cs
+++ b/Source/Core/Editor/UI/Windows/ProcessMenuView.cs
@@ -15,7 +15,7 @@ using VRBuilder.Editor.UndoRedo;
 namespace VRBuilder.Editor.UI.Windows
 {
     /// <summary>
-    /// ProcessMenuView is shown on the left side of the <see cref="ProcessWindow"/> and takes care about overall
+    /// ProcessMenuView is shown on the left side of the <see cref="ProcessGraphViewWindow"/> and takes care about overall
     /// settings for the process itself, especially chapters.
     /// </summary>
     internal class ProcessMenuView : ScriptableObject

--- a/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
+++ b/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
@@ -27,15 +27,19 @@ namespace VRBuilder.Core.Configuration
 
         /// <summary>
         /// Fully qualified name of the runtime configuration used.
-        /// This field is magically filled by <see cref="RuntimeConfiguratorEditor"/>
         /// </summary>
+        /// <remarks>
+        /// This field is filled by <see cref="RuntimeConfiguratorEditor"/>
+        /// </remarks>
         [SerializeField]
         private string runtimeConfigurationName = typeof(DefaultRuntimeConfiguration).AssemblyQualifiedName;
 
         /// <summary>
         /// Process name which is selected.
-        /// This field is magically filled by <see cref="RuntimeConfiguratorEditor"/>
         /// </summary>
+        /// <remarks>
+        /// This field is filled by <see cref="RuntimeConfiguratorEditor"/>
+        /// </remarks>
         [SerializeField]
         private string selectedProcessStreamingAssetsPath = "";
 
@@ -48,38 +52,78 @@ namespace VRBuilder.Core.Configuration
         private BaseRuntimeConfiguration runtimeConfiguration;
 
         private static RuntimeConfigurator instance;
+        private static RuntimeConfigurator[] instances;
 
-        private static RuntimeConfigurator LookUpForGameObject()
+        /// <summary>
+        /// Looks up all the RuntimeConfigurator game objects in the scene.
+        /// </summary>
+        /// <returns>An array of RuntimeConfigurator instances found in the scene.</returns>
+        private static RuntimeConfigurator[] LookUpRuntimeConfiguratorGameObjects()
         {
             RuntimeConfigurator[] instances = FindObjectsOfType<RuntimeConfigurator>();
 
-            if (instances.Length > 1)
-            {
-                Debug.LogError("More than one process runtime configurator is found in the scene. Taking the first one. This may lead to unexpected behaviour.");
-            }
+            return instances;
+        }
+
+        /// <summary>
+        /// Gets the RuntimeConfigurator instance.
+        /// </summary>
+        /// <returns>The active RuntimeConfigurator instance.</returns>
+        /// <remarks>
+        /// If there are multiple instances of the RuntimeConfigurator in the scene, the first one found will be used and
+        /// a warning will be logged. 
+        /// </remarks>
+        private static RuntimeConfigurator GetRuntimeConfigurator()
+        {
+            RuntimeConfigurator[] instances = LookUpRuntimeConfiguratorGameObjects();
 
             if (instances.Length == 0)
             {
                 return null;
+            }
+            if (instances.Length > 1)
+            {
+                string errorLog = $"More than one process runtime configurator found in all open scenes. The active process will be {instances[0].GetSelectedProcess()} from Scene {instances[0].gameObject.scene.name}. Ignoring following processes: ";
+                for (int i = 1; i < instances.Length; i++)
+                {
+                    errorLog += $"{instances[i].GetSelectedProcess()} from Scene {instances[i].gameObject.scene.name}";
+                    if (i < instances.Length - 1)
+                    {
+                        errorLog += ", ";
+                    }
+                }
+                Debug.LogError(errorLog);
             }
 
             return instances[0];
         }
 
         /// <summary>
-        /// Checks if a process runtime configurator instance exists in scene.
+        /// Checks if a process runtime configurator exists in the scene.
         /// </summary>
+        /// <returns><c>true</c> if an instance of the runtime configurator exists; otherwise, <c>false</c>.</returns>
         public static bool Exists
         {
             get
             {
-                if (instance == null || instance.Equals(null))
-                {
-                    instance = LookUpForGameObject();
-                }
-
-                return (instance != null && instance.Equals(null) == false);
+                return IsExisting();
             }
+        }
+
+        /// <summary>
+        /// Checks if an instance of the runtime configurator exists.
+        /// If <see cref="instance"/> is not set it tries to set it by calling <see cref="LookUpRuntimeConfiguratorGameObject"/>.
+        /// </summary>
+        /// <param name="forceNewLookup">If set to <c>true</c>, forces a new lookup for the instance.</param>
+        /// <returns><c>true</c> if an instance of the runtime configurator exists; otherwise, <c>false</c>.</returns>
+        public static bool IsExisting(bool forceNewLookup = false)
+        {
+            if (instance == null || instance.Equals(null) || forceNewLookup)
+            {
+                instance = GetRuntimeConfigurator();
+            }
+
+            return instance != null && instance.Equals(null) == false;
         }
 
         /// <summary>
@@ -134,9 +178,9 @@ namespace VRBuilder.Core.Configuration
         }
 
         /// <summary>
-        /// Current instance of the RuntimeConfigurator.
+        /// Gets the current instance of the RuntimeConfigurator.
         /// </summary>
-        /// <exception cref="NullReferenceException">Will throw a NPE if there is no RuntimeConfigurator added to the scene.</exception>
+        /// <exception cref="NullReferenceException">Thrown if there is no RuntimeConfigurator added to the scene.</exception>
         public static RuntimeConfigurator Instance
         {
             get
@@ -153,6 +197,7 @@ namespace VRBuilder.Core.Configuration
         /// <summary>
         /// Returns the assembly qualified name of the runtime configuration.
         /// </summary>
+        /// <returns>The assembly qualified name of the runtime configuration.</returns>
         public string GetRuntimeConfigurationName()
         {
             return runtimeConfigurationName;
@@ -161,6 +206,7 @@ namespace VRBuilder.Core.Configuration
         /// <summary>
         /// Sets the runtime configuration name, expects an assembly qualified name.
         /// </summary>
+        /// <param name="configurationName">The assembly qualified name of the runtime configuration.</param>
         public void SetRuntimeConfigurationName(string configurationName)
         {
             runtimeConfigurationName = configurationName;
@@ -169,6 +215,7 @@ namespace VRBuilder.Core.Configuration
         /// <summary>
         /// Returns the path to the selected process.
         /// </summary>
+        /// <returns>The path to the selected process.</returns>
         public string GetSelectedProcess()
         {
             return selectedProcessStreamingAssetsPath;
@@ -177,6 +224,7 @@ namespace VRBuilder.Core.Configuration
         /// <summary>
         /// Sets the path to the selected process.
         /// </summary>
+        /// <param name="path">The path to the selected process.</param>
         public void SetSelectedProcess(string path)
         {
             selectedProcessStreamingAssetsPath = path;
@@ -185,6 +233,7 @@ namespace VRBuilder.Core.Configuration
         /// <summary>
         /// Returns the string localization table for the selected process.
         /// </summary>
+        /// <returns>The string localization table for the selected process.</returns>
         public string GetProcessStringLocalizationTable()
         {
             return processStringLocalizationTable;


### PR DESCRIPTION
Showing a warning process window when no process is loaded.
Feature is based on https://github.com/MindPort-GmbH/VR-Builder/pull/222 will be less changes after this is merged.

EDIT:
Learned something new. Seems like git does not pic up the merged changes from https://github.com/MindPort-GmbH/VR-Builder/pull/222 because they are squashed :-/. 
Would not have expected this. Most stuff in e.g. RuntimeConfigurator. ProcessAssetManager and GlobalEditorHandler is allread in develop.