### PR TITLE
Added check for kinematic before resetting velocity in move object behavior

### DIFF
--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
@@ -88,7 +88,7 @@ namespace VRBuilder.Core.Behaviors
                 RuntimeConfigurator.Configuration.SceneObjectManager.RequestAuthority(Data.TargetObject.Value);
 
                 Rigidbody movingRigidbody = Data.TargetObject.Value.GameObject.GetComponent<Rigidbody>();
-                if (movingRigidbody != null)
+                if (movingRigidbody != null && movingRigidbody.isKinematic == false)
                 {
                     movingRigidbody.velocity = Vector3.zero;
                     movingRigidbody.angularVelocity = Vector3.zero;
@@ -129,7 +129,7 @@ namespace VRBuilder.Core.Behaviors
                 movingTransform.rotation = targetPositionTransform.rotation;
 
                 Rigidbody movingRigidbody = Data.TargetObject.Value.GameObject.GetComponent<Rigidbody>();
-                if (movingRigidbody != null)
+                if (movingRigidbody != null && movingRigidbody.isKinematic == false)
                 {
                     movingRigidbody.velocity = Vector3.zero;
                     movingRigidbody.angularVelocity = Vector3.zero;


### PR DESCRIPTION
Now checking for kinematic before resetting velocities as Unity 2022+ throws warnings when attempting to reset velocity on kinematic rigid bodies.