### PR TITLE
Updated single object reference warning text

### DIFF
--- a/Source/Core/Editor/UI/Drawers/ProcessSceneReferenceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/ProcessSceneReferenceDrawer.cs
@@ -90,7 +90,7 @@ namespace VRBuilder.Editor.UI.Drawers
 
             if (!allowMultipleValues && groupedObjectsCount > 1)
             {
-                message = "This only supports a single scene object at a time.";
+                message = "Multiple objects referenced. Only one will be used.";
                 messageType = MessageType.Warning;
             }
             else if (groupedObjectsCount == 0)


### PR DESCRIPTION
Tried to keep it short.

<!-- greptile_comment -->

## Greptile Summary



The PR updates the warning message in `ProcessSceneReferenceDrawer.cs` to clarify that only one object will be used when multiple are referenced.

- Updated warning message in `/Source/Core/Editor/UI/Drawers/ProcessSceneReferenceDrawer.cs` to "Multiple objects referenced. Only one will be used."
- Ensures users understand the limitation when multiple objects are referenced but only one is allowed.

<!-- /greptile_comment -->