### PR TITLE
Added possibility to abort entity lifecycles

### DIFF
--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/BehaviorSequence.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/BehaviorSequence.cs
@@ -7,6 +7,7 @@ using UnityEngine.Scripting;
 using VRBuilder.Core.Attributes;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 
 namespace VRBuilder.Core.Behaviors
 {
@@ -219,6 +220,12 @@ namespace VRBuilder.Core.Behaviors
         public override IStageProcess GetDeactivatingProcess()
         {
             return new StopEntityIteratingProcess<IBehavior>(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         /// <inheritdoc />

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChapterBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChapterBehavior.cs
@@ -1,10 +1,11 @@
-using System.Collections;
-using System.Runtime.Serialization;
-using VRBuilder.Core.Attributes;
 using Newtonsoft.Json;
-using UnityEngine.Scripting;
-using VRBuilder.Core.EntityOwners;
+using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+using UnityEngine.Scripting;
+using VRBuilder.Core.Attributes;
+using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 
 namespace VRBuilder.Core.Behaviors
 {
@@ -126,6 +127,12 @@ namespace VRBuilder.Core.Behaviors
         public override IStageProcess GetDeactivatingProcess()
         {
             return new DeactivatingProcess(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         /// <inheritdoc />

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChaptersBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChaptersBehavior.cs
@@ -1,11 +1,12 @@
-using System.Collections;
-using System.Runtime.Serialization;
-using VRBuilder.Core.Attributes;
 using Newtonsoft.Json;
-using UnityEngine.Scripting;
-using VRBuilder.Core.EntityOwners;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
+using UnityEngine.Scripting;
+using VRBuilder.Core.Attributes;
+using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 
 namespace VRBuilder.Core.Behaviors
 {
@@ -58,7 +59,7 @@ namespace VRBuilder.Core.Behaviors
             /// <inheritdoc />
             public override void Start()
             {
-                foreach(IChapter chapter in Data.Chapters)
+                foreach (IChapter chapter in Data.Chapters)
                 {
                     chapter.LifeCycle.Activate();
                 }
@@ -67,7 +68,7 @@ namespace VRBuilder.Core.Behaviors
             /// <inheritdoc />
             public override IEnumerator Update()
             {
-                while(Data.Chapters.Select(chapter => chapter.LifeCycle.Stage).Any(stage => stage != Stage.Active)) 
+                while (Data.Chapters.Select(chapter => chapter.LifeCycle.Stage).Any(stage => stage != Stage.Active))
                 {
                     foreach (IChapter chapter in Data.Chapters.Where(chapter => chapter.LifeCycle.Stage != Stage.Active))
                     {
@@ -151,6 +152,12 @@ namespace VRBuilder.Core.Behaviors
         public override IStageProcess GetDeactivatingProcess()
         {
             return new DeactivatingProcess(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         /// <inheritdoc />

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChaptersBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/ExecuteChaptersBehavior.cs
@@ -68,7 +68,7 @@ namespace VRBuilder.Core.Behaviors
             /// <inheritdoc />
             public override IEnumerator Update()
             {
-                while (Data.Chapters.Select(chapter => chapter.LifeCycle.Stage).Any(stage => stage != Stage.Active))
+                while (Data.Chapters.Any(chapter => chapter.LifeCycle.Stage != Stage.Active))
                 {
                     foreach (IChapter chapter in Data.Chapters.Where(chapter => chapter.LifeCycle.Stage != Stage.Active))
                     {

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/GoToChapterBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/GoToChapterBehavior.cs
@@ -59,6 +59,8 @@ namespace VRBuilder.Core.Behaviors
                 {
                     ProcessRunner.SetNextChapter(chapter);
                 }
+
+                ProcessRunner.Current.Data.Current.LifeCycle.Abort();
             }
 
             /// <inheritdoc />

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/GoToChapterBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/GoToChapterBehavior.cs
@@ -9,7 +9,7 @@ using VRBuilder.Core.Attributes;
 namespace VRBuilder.Core.Behaviors
 {
     /// <summary>
-    /// This behavior sets the next chapter to an arbitrary chapter and fast forwards to the end of the current chapter.
+    /// This behavior sets the next chapter to an arbitrary chapter and immediately aborts the current chapter.
     /// </summary>
     [DataContract(IsReference = true)]
     public class GoToChapterBehavior : Behavior<GoToChapterBehavior.EntityData>
@@ -17,7 +17,7 @@ namespace VRBuilder.Core.Behaviors
         /// <summary>
         /// Behavior data.
         /// </summary>
-        [DisplayName("Start Chapter")]
+        [DisplayName("Go to Chapter")]
         [DataContract(IsReference = true)]
         public class EntityData : IBehaviorData
         {
@@ -25,7 +25,9 @@ namespace VRBuilder.Core.Behaviors
             public Guid ChapterGuid { get; set; }
 
             public Metadata Metadata { get; set; }
-            public string Name { get; set; }
+
+            [IgnoreDataMember]
+            public string Name => "Go to Chapter";
         }
 
         [JsonConstructor, Preserve]
@@ -33,10 +35,9 @@ namespace VRBuilder.Core.Behaviors
         {
         }
 
-        public GoToChapterBehavior(Guid chapterGuid, string name = "Go to Chapter")
+        public GoToChapterBehavior(Guid chapterGuid)
         {
             Data.ChapterGuid = chapterGuid;
-            Data.Name = name;
         }
 
         private class ActivatingProcess : StageProcess<EntityData>
@@ -60,7 +61,7 @@ namespace VRBuilder.Core.Behaviors
                     ProcessRunner.SetNextChapter(chapter);
                 }
 
-                ProcessRunner.Current.Data.Current.LifeCycle.Abort();
+                ProcessRunner.Current.Data.Current?.LifeCycle.Abort();
             }
 
             /// <inheritdoc />

--- a/Source/Core/Editor/UI/GraphView/NodeInstantiators/EndChapterNodeInstantiator.cs
+++ b/Source/Core/Editor/UI/GraphView/NodeInstantiators/EndChapterNodeInstantiator.cs
@@ -9,7 +9,7 @@ namespace VRBuilder.Editor.UI.Graphics
     public class EndChapterNodeInstantiator : IStepNodeInstantiator
     {
         /// <inheritdoc/>
-        public string Name => "Set Next Chapter";
+        public string Name => "End Chapter";
 
         /// <inheritdoc/>
         public bool IsInNodeMenu => true;
@@ -23,14 +23,7 @@ namespace VRBuilder.Editor.UI.Graphics
         /// <inheritdoc/>
         public DropdownMenuAction.Status GetContextMenuStatus(IEventHandler target, IChapter currentChapter)
         {
-            if (GlobalEditorHandler.GetCurrentProcess().Data.Chapters.Contains(currentChapter))
-            {
-                return DropdownMenuAction.Status.Normal;
-            }
-            else
-            {
-                return DropdownMenuAction.Status.Disabled;
-            }
+            return DropdownMenuAction.Status.Normal;
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Runtime/BehaviorCollection.cs
+++ b/Source/Core/Runtime/BehaviorCollection.cs
@@ -65,6 +65,12 @@ namespace VRBuilder.Core
         }
 
         /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
+        }
+
+        /// <inheritdoc />
         protected override IConfigurator GetConfigurator()
         {
             return new ParallelConfigurator<IBehavior>(Data);

--- a/Source/Core/Runtime/Chapter.cs
+++ b/Source/Core/Runtime/Chapter.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using VRBuilder.Core.Attributes;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 using VRBuilder.Core.Exceptions;
 using VRBuilder.Core.Utils;
 using VRBuilder.Core.Utils.Logging;
@@ -181,6 +182,12 @@ namespace VRBuilder.Core
         public override IStageProcess GetDeactivatingProcess()
         {
             return new StopEntityIteratingProcess<IStep>(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         /// <inheritdoc />

--- a/Source/Core/Runtime/Conditions/Condition.cs
+++ b/Source/Core/Runtime/Conditions/Condition.cs
@@ -48,5 +48,23 @@ namespace VRBuilder.Core.Conditions
         {
             return PropertyReflectionHelper.ExtractLockablePropertiesFromCondition(Data);
         }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new AbortingProcess(Data);
+        }
+
+        private class AbortingProcess : InstantProcess<IConditionData>
+        {
+            public AbortingProcess(IConditionData data) : base(data)
+            {
+            }
+
+            public override void Start()
+            {
+                Data.IsCompleted = false;
+            }
+        }
     }
 }

--- a/Source/Core/Runtime/Conditions/Condition.cs
+++ b/Source/Core/Runtime/Conditions/Condition.cs
@@ -48,23 +48,5 @@ namespace VRBuilder.Core.Conditions
         {
             return PropertyReflectionHelper.ExtractLockablePropertiesFromCondition(Data);
         }
-
-        /// <inheritdoc />
-        public override IStageProcess GetAbortingProcess()
-        {
-            return new AbortingProcess(Data);
-        }
-
-        private class AbortingProcess : InstantProcess<IConditionData>
-        {
-            public AbortingProcess(IConditionData data) : base(data)
-            {
-            }
-
-            public override void Start()
-            {
-                Data.IsCompleted = false;
-            }
-        }
     }
 }

--- a/Source/Core/Runtime/Entity.cs
+++ b/Source/Core/Runtime/Entity.cs
@@ -59,7 +59,7 @@ namespace VRBuilder.Core
         }
 
         /// <inheritdoc />
-        public IStageProcess GetAbortingProcess()
+        public virtual IStageProcess GetAbortingProcess()
         {
             return new EmptyProcess();
         }

--- a/Source/Core/Runtime/Entity.cs
+++ b/Source/Core/Runtime/Entity.cs
@@ -58,6 +58,12 @@ namespace VRBuilder.Core
             return new EmptyProcess();
         }
 
+        /// <inheritdoc />
+        public IStageProcess GetAbortingProcess()
+        {
+            return new EmptyProcess();
+        }
+
         /// <summary>
         /// Override this method if your behavior or condition supports changing between process modes (<see cref="IMode"/>).
         /// By default returns an empty configurator that does nothing.

--- a/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
+++ b/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Linq;
 using UnityEngine;
 using VRBuilder.Core.Configuration.Modes;
 
@@ -6,19 +8,35 @@ namespace VRBuilder.Core.EntityOwners.ParallelEntityCollection
     /// <summary>
     /// A process over a collection of entities which aborts them at the same time, in parallel.
     /// </summary>
-    internal class ParallelAbortingProcess<TCollectionData> : InstantProcess<TCollectionData> where TCollectionData : class, IEntityCollectionData, IModeData
+    internal class ParallelAbortingProcess<TCollectionData> : StageProcess<TCollectionData> where TCollectionData : class, IEntityCollectionData, IModeData
     {
         public ParallelAbortingProcess(TCollectionData data) : base(data)
+        {
+        }
+
+        public override void End()
+        {
+        }
+
+        public override void FastForward()
         {
         }
 
         /// <inheritdoc />
         public override void Start()
         {
-            foreach (IEntity child in Data.GetChildren())
+            foreach (IEntity child in Data.GetChildren().Where(child => child.LifeCycle.Stage != Stage.Inactive))
             {
                 Debug.Log($"Aborting ´{child}");
                 child.LifeCycle.Abort();
+            }
+        }
+
+        public override IEnumerator Update()
+        {
+            while (Data.GetChildren().Any(child => child.LifeCycle.Stage != Stage.Inactive))
+            {
+                yield return null;
             }
         }
     }

--- a/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
+++ b/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using VRBuilder.Core.Configuration.Modes;
+
+namespace VRBuilder.Core.EntityOwners.ParallelEntityCollection
+{
+    /// <summary>
+    /// A process over a collection of entities which aborts them at the same time, in parallel.
+    /// </summary>
+    internal class ParallelAbortingProcess<TCollectionData> : InstantProcess<TCollectionData> where TCollectionData : class, IEntityCollectionData, IModeData
+    {
+        public ParallelAbortingProcess(TCollectionData data) : base(data)
+        {
+        }
+
+        /// <inheritdoc />
+        public override void Start()
+        {
+            foreach (IEntity child in Data.GetChildren())
+            {
+                Debug.Log($"Aborting ´{child}");
+                child.LifeCycle.Abort();
+            }
+        }
+    }
+}

--- a/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
+++ b/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Linq;
-using UnityEngine;
 
 namespace VRBuilder.Core.EntityOwners.ParallelEntityCollection
 {
@@ -26,7 +25,6 @@ namespace VRBuilder.Core.EntityOwners.ParallelEntityCollection
         {
             foreach (IEntity child in Data.GetChildren().Where(child => child.LifeCycle.Stage != Stage.Inactive))
             {
-                Debug.Log($"Aborting ´{child}");
                 child.LifeCycle.Abort();
             }
         }

--- a/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
+++ b/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs
@@ -1,14 +1,13 @@
 using System.Collections;
 using System.Linq;
 using UnityEngine;
-using VRBuilder.Core.Configuration.Modes;
 
 namespace VRBuilder.Core.EntityOwners.ParallelEntityCollection
 {
     /// <summary>
     /// A process over a collection of entities which aborts them at the same time, in parallel.
     /// </summary>
-    internal class ParallelAbortingProcess<TCollectionData> : StageProcess<TCollectionData> where TCollectionData : class, IEntityCollectionData, IModeData
+    internal class ParallelAbortingProcess<TCollectionData> : StageProcess<TCollectionData> where TCollectionData : class, IEntityCollectionData
     {
         public ParallelAbortingProcess(TCollectionData data) : base(data)
         {

--- a/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs.meta
+++ b/Source/Core/Runtime/EntityOwners/Parallel/ParallelAbortingProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4526acf9cef3a0c49a8d30d4a34d1b3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Core/Runtime/EntityOwners/Sequence/EntityIteratingProcess.cs
+++ b/Source/Core/Runtime/EntityOwners/Sequence/EntityIteratingProcess.cs
@@ -58,7 +58,7 @@ namespace VRBuilder.Core.EntityOwners
                     yield return null;
                 }
 
-                if (Data.Current.LifeCycle.Stage != Stage.Inactive)
+                if (Data.Current.LifeCycle.Stage != Stage.Inactive && Data.Current.LifeCycle.Stage != Stage.Aborting)
                 {
                     Data.Current.LifeCycle.Deactivate();
                 }

--- a/Source/Core/Runtime/IEntity.cs
+++ b/Source/Core/Runtime/IEntity.cs
@@ -34,6 +34,11 @@ namespace VRBuilder.Core
         IStageProcess GetDeactivatingProcess();
 
         /// <summary>
+        /// Returns a new instance of a process for the Aborting <seealso cref="Stage"/>.
+        /// </summary>
+        IStageProcess GetAbortingProcess();
+
+        /// <summary>
         /// Configures the entity according to the given <paramref name="mode"/>.
         /// </summary>
         void Configure(IMode mode);

--- a/Source/Core/Runtime/ILifeCycle.cs
+++ b/Source/Core/Runtime/ILifeCycle.cs
@@ -27,7 +27,7 @@ namespace VRBuilder.Core
         void Activate();
 
         /// <summary>
-        /// Immediately brings the lifecycle back to the Inactive stage.
+        /// Enters Aborting stage, which will cause the entity to switch to inactive when completed.
         /// </summary>
         void Abort();
 

--- a/Source/Core/Runtime/ILifeCycle.cs
+++ b/Source/Core/Runtime/ILifeCycle.cs
@@ -27,6 +27,11 @@ namespace VRBuilder.Core
         void Activate();
 
         /// <summary>
+        /// Immediately brings the lifecycle back to the Inactive stage.
+        /// </summary>
+        void Abort();
+
+        /// <summary>
         /// Enters Deactivating stage if was Active. If was Activating, will start deactivating as soon as it enters Active stage.
         /// </summary>
         void Deactivate();

--- a/Source/Core/Runtime/LifeCycle.cs
+++ b/Source/Core/Runtime/LifeCycle.cs
@@ -242,7 +242,7 @@ namespace VRBuilder.Core
 
         private void StartAborting()
         {
-            ChangeStage(Stage.Aborting);
+            ChangeStage(Stage.Aborting, false);
 
             if (IsInFastForward)
             {
@@ -284,10 +284,13 @@ namespace VRBuilder.Core
             update = process.Update();
         }
 
-        private void ChangeStage(Stage stage)
+        private void ChangeStage(Stage stage, bool fastForward = true)
         {
             // Interrupt and fast-forward the current stage process, if it had no time to iterate completely.
-            FastForward();
+            if (fastForward)
+            {
+                FastForward();
+            }
 
             Stage = stage;
             SetCurrentStageProcess();

--- a/Source/Core/Runtime/Process.cs
+++ b/Source/Core/Runtime/Process.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization;
 using VRBuilder.Core.Attributes;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 
 namespace VRBuilder.Core
 {
@@ -142,6 +143,12 @@ namespace VRBuilder.Core
         public override IStageProcess GetDeactivatingProcess()
         {
             return new StopEntityIteratingProcess<IChapter>(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         /// <inheritdoc />

--- a/Source/Core/Runtime/RestrictiveEnvironment/DefaultStepLockHandling.cs
+++ b/Source/Core/Runtime/RestrictiveEnvironment/DefaultStepLockHandling.cs
@@ -86,14 +86,7 @@ namespace VRBuilder.Core.RestrictiveEnvironment
 
             foreach (LockablePropertyData lockable in lockList)
             {
-                if (completedTransition != null)
-                {
-                    lockable.Property.RequestLocked(true, data);
-                }
-                else
-                {
-                    lockable.Property.RequestLocked(true);
-                }
+                lockable.Property.RequestLocked(true, data);
             }
         }
 

--- a/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonProcessSerializer.cs
+++ b/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonProcessSerializer.cs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2024 MindPort GmbH
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.Serialization.NewtonsoftJson;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace VRBuilder.Core.Serialization
 {
@@ -97,7 +97,7 @@ namespace VRBuilder.Core.Serialization
                             continue;
                         }
 
-                        StepRef stepRef = (StepRef) transition.Data.TargetStep;
+                        StepRef stepRef = (StepRef)transition.Data.TargetStep;
                         transition.Data.TargetStep = stepRef.PositionIndex >= 0 ? Steps[stepRef.PositionIndex] : null;
                     }
                 }
@@ -143,6 +143,11 @@ namespace VRBuilder.Core.Serialization
                 }
 
                 public IStep Clone()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IStageProcess GetAbortingProcess()
                 {
                     throw new NotImplementedException();
                 }

--- a/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonProcessSerializerV3.cs
+++ b/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonProcessSerializerV3.cs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2024 MindPort GmbH
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using VRBuilder.Core.Configuration.Modes;
-using VRBuilder.Core.Serialization.NewtonsoftJson;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Linq;
 using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.Serialization.NewtonsoftJson;
 
 namespace VRBuilder.Core.Serialization
 {
@@ -37,7 +37,7 @@ namespace VRBuilder.Core.Serialization
             {
                 return base.ProcessFromByteArray(data);
             }
-            if(version == 2)
+            if (version == 2)
             {
                 return new ImprovedNewtonsoftJsonProcessSerializer().ProcessFromByteArray(data);
             }
@@ -103,7 +103,7 @@ namespace VRBuilder.Core.Serialization
                             continue;
                         }
 
-                        StepRef stepRef = (StepRef) transition.Data.TargetStep;
+                        StepRef stepRef = (StepRef)transition.Data.TargetStep;
                         transition.Data.TargetStep = stepRef.PositionIndex >= 0 ? Steps[stepRef.PositionIndex] : null;
                     }
                 }
@@ -122,9 +122,9 @@ namespace VRBuilder.Core.Serialization
                     .Cast<IEntityCollectionData<IChapter>>()
                     .SelectMany(behavior => behavior.GetChildren());
 
-                foreach(IChapter subChapter in subChapters)
+                foreach (IChapter subChapter in subChapters)
                 {
-                    steps.AddRange(GetSteps(subChapter)); 
+                    steps.AddRange(GetSteps(subChapter));
                 }
 
                 return steps;
@@ -168,6 +168,11 @@ namespace VRBuilder.Core.Serialization
                 }
 
                 public IStep Clone()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IStageProcess GetAbortingProcess()
                 {
                     throw new NotImplementedException();
                 }

--- a/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonProcessSerializerV4.cs
+++ b/Source/Core/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonProcessSerializerV4.cs
@@ -401,6 +401,11 @@ namespace VRBuilder.Core.Serialization
                     throw new NotImplementedException();
                 }
 
+                public IStageProcess GetAbortingProcess()
+                {
+                    throw new NotImplementedException();
+                }
+
                 public StepMetadata StepMetadata { get; set; }
                 public IEntity Parent { get; set; }
             }

--- a/Source/Core/Runtime/Stage.cs
+++ b/Source/Core/Runtime/Stage.cs
@@ -12,6 +12,7 @@ namespace VRBuilder.Core
         Inactive,
         Activating,
         Active,
-        Deactivating
+        Deactivating,
+        Aborting
     }
 }

--- a/Source/Core/Runtime/Transition.cs
+++ b/Source/Core/Runtime/Transition.cs
@@ -10,6 +10,7 @@ using VRBuilder.Core.Attributes;
 using VRBuilder.Core.Conditions;
 using VRBuilder.Core.Configuration.Modes;
 using VRBuilder.Core.EntityOwners;
+using VRBuilder.Core.EntityOwners.ParallelEntityCollection;
 using VRBuilder.Core.RestrictiveEnvironment;
 using VRBuilder.Core.Utils.Logging;
 using VRBuilder.Unity;
@@ -145,6 +146,12 @@ namespace VRBuilder.Core
         public override IStageProcess GetDeactivatingProcess()
         {
             return new EntityOwners.ParallelEntityCollection.ParallelDeactivatingProcess<EntityData>(Data);
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
         }
 
         ///<inheritdoc />

--- a/Source/Core/Runtime/TransitionCollection.cs
+++ b/Source/Core/Runtime/TransitionCollection.cs
@@ -106,6 +106,12 @@ namespace VRBuilder.Core
             return new ParallelDeactivatingProcess<EntityData>(Data);
         }
 
+        /// <inheritdoc />
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new ParallelAbortingProcess<EntityData>(Data);
+        }
+
         ///<inheritdoc />
         public ITransitionCollection Clone()
         {

--- a/Tests/Core/PlayMode/Processes/LifeCycleTests.cs
+++ b/Tests/Core/PlayMode/Processes/LifeCycleTests.cs
@@ -1,12 +1,13 @@
 // Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021-2024 MindPort GmbH
+using NUnit.Framework;
 using System.Collections;
-using UnityEngine.Assertions;
 using UnityEngine.TestTools;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.Configuration.Modes;
+using VRBuilder.Core.Exceptions;
 using VRBuilder.Core.Tests.RuntimeUtils;
 using VRBuilder.Core.Tests.Utils.Builders;
 using VRBuilder.Core.Tests.Utils.Mocks;
@@ -176,7 +177,111 @@ namespace VRBuilder.Core.Tests.Processes
             step.Update();
 
             Assert.AreEqual(Stage.Active, step.LifeCycle.Stage);
+        }
 
+        [UnityTest]
+        public IEnumerator NoChangeInChapterIfCurrentStepIsAborted()
+        {
+            // Given a chapter,            
+            LinearChapterBuilder chapterBuilder = new LinearChapterBuilder("TestChapter")
+                .AddStep(new BasicStepBuilder("1")
+                    .AddBehavior(new EndlessBehaviorMock()))
+                .AddStep(new BasicStepBuilder("2")
+                    .AddBehavior(new EndlessBehaviorMock()));
+
+            IChapter chapter = chapterBuilder.Build();
+            chapter.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
+            chapter.LifeCycle.Activate();
+
+            yield return null;
+            chapter.Update();
+
+            Assert.AreEqual("1", chapter.Data.Current.Data.Name);
+            Assert.AreEqual(Stage.Activating, chapter.Data.Current.LifeCycle.Stage);
+
+            // If the current step is aborted,
+            chapter.Data.Current.LifeCycle.Abort();
+
+            while (chapter.Data.Current.LifeCycle.Stage != Stage.Inactive)
+            {
+                yield return null;
+                chapter.Update();
+            }
+
+            // Then nothing changes in the state of the chapter.
+            Assert.AreEqual(Stage.Activating, chapter.LifeCycle.Stage);
+            Assert.AreEqual("1", chapter.Data.Current.Data.Name);
+        }
+
+        [UnityTest]
+        public IEnumerator ProcessMovesToNextChapterIfChapterIsAborted()
+        {
+            // Given a process,
+            IProcess process = new LinearProcessBuilder("Process")
+                .AddChapter(new LinearChapterBuilder("C1")
+                    .AddStep(new BasicStepBuilder("1").AddBehavior(new EndlessBehaviorMock())))
+                .AddChapter(new LinearChapterBuilder("C2")
+                    .AddStep(new BasicStepBuilder("2").AddBehavior(new EndlessBehaviorMock())))
+                .Build();
+            process.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);
+            process.LifeCycle.Activate();
+
+            yield return null;
+            process.Update();
+
+            Assert.AreEqual(Stage.Activating, process.Data.Current.LifeCycle.Stage);
+
+            // If a chapter is aborted,
+            process.Data.Current.LifeCycle.Abort();
+
+            while (process.Data.Current.LifeCycle.Stage != Stage.Inactive)
+            {
+                yield return null;
+                process.Update();
+            }
+
+            yield return null;
+            process.Update();
+
+            // Then the process moves to the next chapter.
+            Assert.AreEqual("C2", process.Data.Current.Data.Name);
+            Assert.AreEqual(Stage.Activating, process.Data.Current.LifeCycle.Stage);
+        }
+
+        [UnityTest]
+        public IEnumerator ExceptionThrownWhenAbortingInactiveEntity()
+        {
+            // Given an inactive entity,
+            IBehavior behavior = new EndlessBehaviorMock();
+
+            // When it is aborted,
+            TestDelegate abort = new TestDelegate(() => behavior.LifeCycle.Abort());
+
+            // An exception is thrown.
+            Assert.Throws<InvalidStateException>(abort);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ExceptionThrownWhenAbortingAbortingEntity()
+        {
+            // Given an aborting entity,
+            IBehavior behavior = new EndlessBehaviorMock();
+            behavior.LifeCycle.Activate();
+
+            yield return null;
+            behavior.LifeCycle.Update();
+
+            Assert.AreEqual(Stage.Activating, behavior.LifeCycle.Stage);
+
+            behavior.LifeCycle.Abort();
+
+            // When it is aborted,
+            TestDelegate abort = new TestDelegate(() => behavior.LifeCycle.Abort());
+
+            // An exception is thrown.
+            Assert.Throws<InvalidStateException>(abort);
         }
     }
 }

--- a/Tests/Core/PlayMode/Processes/LifeCycleTests.cs
+++ b/Tests/Core/PlayMode/Processes/LifeCycleTests.cs
@@ -58,6 +58,28 @@ namespace VRBuilder.Core.Tests.Processes
         }
 
         [UnityTest]
+        public IEnumerator EntityIsAborted()
+        {
+            // Given a running entity,
+            IEntity entity = new EndlessBehaviorMock();
+
+            entity.LifeCycle.Activate();
+
+            Assert.AreEqual(Stage.Activating, entity.LifeCycle.Stage);
+
+            // When it is aborted,
+            entity.LifeCycle.Abort();
+
+            // Then it goes back to inactive.
+            Assert.AreEqual(Stage.Aborting, entity.LifeCycle.Stage);
+
+            entity.LifeCycle.Update();
+            yield return null;
+
+            Assert.AreEqual(Stage.Inactive, entity.LifeCycle.Stage);
+        }
+
+        [UnityTest]
         public IEnumerator FastForwardNextStage()
         {
             // Given an entity,


### PR DESCRIPTION
- An aborted Process ends.
- If a process Chapter is aborted, the process starts the next Chapter.
- If a Chapter nested into a behavior is aborted, it goes inactive and stops blocking the behavior.
- If a Step is aborted, then the current step of the chapter is inactive and everything pauses.
- If a Behavior/Condition is aborted, the step continues without it. A condition might become uncompletable.

<!-- greptile_comment -->

## Greptile Summary



This pull request introduces the ability to abort entity lifecycles in VR Builder, focusing on improving process handling and error management.

- Added check for Aborting stage in `EntityIteratingProcess.Update()` method to prevent unnecessary deactivation of aborting entities
- Expanded `LifeCycleTests.cs` with new tests for aborting entities, processes, and handling related exceptions
- Improved graceful handling of aborted entities in parallel processes, potentially affecting debugging visibility

<!-- /greptile_comment -->