### PR TITLE
Removed cref from IEntity documentation

### DIFF
--- a/Source/Core/Runtime/IEntity.cs
+++ b/Source/Core/Runtime/IEntity.cs
@@ -9,7 +9,7 @@ namespace VRBuilder.Core
     /// <summary>
     /// The basic interface for all components of a process: behaviors, conditions, transitions, and so on.
     /// Do not implement this interface directly.
-    /// Use <see cref="Behaviors.Behavior"/> or <see cref="Conditions.Condition"/> abstract classes instead.
+    /// Use Behavior or Condition abstract classes instead.
     /// </summary>
     public interface IEntity
     {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary



This pull request removes `cref` XML documentation tags from the `IEntity` interface in the `Source/Core/Runtime/IEntity.cs` file, simplifying references to 'Behavior' and 'Condition' classes in the documentation.

- Removed `<see cref="Behaviors.Behavior"/>` and `<see cref="Conditions.Condition"/>` tags, replacing them with plain text 'Behavior' and 'Condition'
- Simplified `<seealso cref="Stage"/>` references to just 'Stage' in method documentation
- Potential impact on documentation generation tools that rely on these tags for cross-referencing
- Consider reviewing other files in the Core Runtime directory for consistency in documentation style

<!-- /greptile_comment -->