### PR TITLE
Make VR builder compatible with unity 6

### DIFF
--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/MoveObjectBehavior.cs
@@ -90,7 +90,7 @@ namespace VRBuilder.Core.Behaviors
                 Rigidbody movingRigidbody = Data.TargetObject.Value.GameObject.GetComponent<Rigidbody>();
                 if (movingRigidbody != null && movingRigidbody.isKinematic == false)
                 {
-                    movingRigidbody.velocity = Vector3.zero;
+                    movingRigidbody.linearVelocity = Vector3.zero;
                     movingRigidbody.angularVelocity = Vector3.zero;
                 }
             }
@@ -131,7 +131,7 @@ namespace VRBuilder.Core.Behaviors
                 Rigidbody movingRigidbody = Data.TargetObject.Value.GameObject.GetComponent<Rigidbody>();
                 if (movingRigidbody != null && movingRigidbody.isKinematic == false)
                 {
-                    movingRigidbody.velocity = Vector3.zero;
+                    movingRigidbody.linearVelocity = Vector3.zero;
                     movingRigidbody.angularVelocity = Vector3.zero;
                 }
             }

--- a/Source/Core/Editor/EditorUtils.cs
+++ b/Source/Core/Editor/EditorUtils.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEditor.Callbacks;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -16,6 +17,7 @@ using VRBuilder.Editor.PackageManager;
 namespace VRBuilder.Editor
 {
     /// <summary>
+    /// Retrieves the current named build target based on the active build target settings in the Unity Editor.
     /// Utility helper to ease up working with Unity Editor.
     /// </summary>
     [InitializeOnLoad]
@@ -52,7 +54,7 @@ namespace VRBuilder.Editor
 
         private static void SetImguiTestsState(bool enabled)
         {
-            List<string> symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Split(';').ToList();
+            List<string> symbols = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.Standalone).Split(';').ToList();
 
             bool wasEnabled = symbols.Contains(ignoreEditorImguiTestsDefineSymbol) == false;
 
@@ -67,7 +69,7 @@ namespace VRBuilder.Editor
                     symbols.Add(ignoreEditorImguiTestsDefineSymbol);
                 }
 
-                PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", symbols.ToArray()));
+                PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.Standalone, string.Join(";", symbols.ToArray()));
                 AssetDatabase.SaveAssets();
                 AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
             }
@@ -122,14 +124,27 @@ namespace VRBuilder.Editor
         }
 
         /// <summary>
+        /// Retrieves the current named build target based on the active build target settings in the Unity Editor.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="NamedBuildTarget"/> object representing the current build target group.
+        /// </returns>
+        internal static NamedBuildTarget GetCurrentNamedBuildTarget()
+        {
+            BuildTarget activeBuildTarget = EditorUserBuildSettings.activeBuildTarget;
+            BuildTargetGroup targetGroup = BuildPipeline.GetBuildTargetGroup(activeBuildTarget);
+            return NamedBuildTarget.FromBuildTargetGroup(targetGroup);
+        }
+
+        /// <summary>
         /// Gets .NET API compatibility level for current BuildTargetGroup.
         /// </summary>
         internal static ApiCompatibilityLevel GetCurrentCompatibilityLevel()
         {
-            BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
-            BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
-            return PlayerSettings.GetApiCompatibilityLevel(buildTargetGroup);
+            return PlayerSettings.GetApiCompatibilityLevel(GetCurrentNamedBuildTarget());
         }
+
+        /// Retrieves the current named build target based on the active build target settings in the Unity Editor.
 
         /// <summary>
         /// Returns a list of scriptable objects from provided type;

--- a/Source/Core/Editor/EditorUtils.cs
+++ b/Source/Core/Editor/EditorUtils.cs
@@ -144,8 +144,6 @@ namespace VRBuilder.Editor
             return PlayerSettings.GetApiCompatibilityLevel(GetCurrentNamedBuildTarget());
         }
 
-        /// Retrieves the current named build target based on the active build target settings in the Unity Editor.
-
         /// <summary>
         /// Returns a list of scriptable objects from provided type;
         /// </summary>

--- a/Source/Core/Editor/UI/GraphView/ProcessGraphNode.cs
+++ b/Source/Core/Editor/UI/GraphView/ProcessGraphNode.cs
@@ -174,7 +174,7 @@ namespace VRBuilder.Editor.UI.Graphics
             if ((e.clickCount == 2) && e.button == (int)MouseButton.LeftMouse && IsRenamable())
             {
                 OpenTextEditor();
-                e.PreventDefault();
+                focusController.IgnoreEvent(e);
                 e.StopImmediatePropagation();
             }
         }

--- a/Source/Core/Editor/UI/GraphView/StepGroupNode.cs
+++ b/Source/Core/Editor/UI/GraphView/StepGroupNode.cs
@@ -42,7 +42,7 @@ namespace VRBuilder.Editor.UI.Graphics
             if ((e.clickCount == 2) && e.button == (int)MouseButton.LeftMouse && IsRenamable())
             {
                 ExpandNode();
-                e.PreventDefault();
+                e.StopPropagation();
                 e.StopImmediatePropagation();
             }
         }
@@ -105,12 +105,12 @@ namespace VRBuilder.Editor.UI.Graphics
                 transition.Data.TargetStep = step;
             }
 
-            if(Behavior.Data.Chapter.Data.Steps.Contains(currentChapter.Data.FirstStep))
+            if (Behavior.Data.Chapter.Data.Steps.Contains(currentChapter.Data.FirstStep))
             {
                 currentChapter.Data.FirstStep = step;
             }
 
-            for(int i = 0; i < Behavior.Data.Chapter.Data.Steps.Count(); i++)
+            for (int i = 0; i < Behavior.Data.Chapter.Data.Steps.Count(); i++)
             {
                 IStep step = Behavior.Data.Chapter.Data.Steps[i];
                 step.StepMetadata.Position = originalPositions[i];
@@ -149,7 +149,7 @@ namespace VRBuilder.Editor.UI.Graphics
         protected override void OnEditTextFinished(TextField textField)
         {
             Behavior.Data.Chapter.Data.SetName(textField.value);
-            base.OnEditTextFinished(textField);            
+            base.OnEditTextFinished(textField);
         }
 
         public void AddContextMenuActions(DropdownMenu menu)
@@ -161,8 +161,8 @@ namespace VRBuilder.Editor.UI.Graphics
 
             menu.AppendAction($"Ungroup", (status) =>
             {
-                ExplodeNode();                
-            });            
+                ExplodeNode();
+            });
         }
     }
 }

--- a/Source/Core/Editor/UI/Menu/AddPropertyExtensionsMenuEntry.cs
+++ b/Source/Core/Editor/UI/Menu/AddPropertyExtensionsMenuEntry.cs
@@ -15,11 +15,11 @@ namespace VRBuilder.Editor.BuilderMenu
         [MenuItem("Tools/VR Builder/Developer/Add Scene Property Extensions", false, 70)]
         private static void AddPropertyExtensions()
         {
-            if(EditorUtility.DisplayDialog("Add Scene Property Extensions?", "This will add the extensions required by the current scene setup to all scene object properties in the scene.\n" +
+            if (EditorUtility.DisplayDialog("Add Scene Property Extensions?", "This will add the extensions required by the current scene setup to all scene object properties in the scene.\n" +
                 "Previously added extensions will not be removed.\n" +
                 "Continue?", "Ok", "Cancel"))
             {
-                IEnumerable<ProcessSceneObject> processSceneObjects = GameObject.FindObjectsOfType<ProcessSceneObject>(true);
+                IEnumerable<ProcessSceneObject> processSceneObjects = GameObject.FindObjectsByType<ProcessSceneObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
                 float processedObjects = 0;
 
                 foreach (ProcessSceneObject processSceneObject in processSceneObjects)

--- a/Source/Core/Editor/UI/Wizard/Setup/AllAboutPage.cs
+++ b/Source/Core/Editor/UI/Wizard/Setup/AllAboutPage.cs
@@ -74,7 +74,7 @@ namespace VRBuilder.Editor.UI.Wizard
 
         private void ConfigureTeleportationLayers()
         {
-            foreach (GameObject configuratorGameObject in GameObject.FindObjectsOfType<GameObject>(true).
+            foreach (GameObject configuratorGameObject in GameObject.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None).
                 Where(go => go.GetComponent<ILayerConfigurator>() != null))
             {
                 ILayerConfigurator configurator = configuratorGameObject.GetComponent<ILayerConfigurator>();

--- a/Source/Core/Editor/Unity/AssemblySymbolChecker.cs
+++ b/Source/Core/Editor/Unity/AssemblySymbolChecker.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.Build;
 using VRBuilder.Editor.Settings;
 
 namespace VRBuilder.Editor.Setup
@@ -86,27 +87,25 @@ namespace VRBuilder.Editor.Setup
 
         private static void AddSymbol(string symbol)
         {
-            BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
-            BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
-            List<string> symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';').ToList();
+            NamedBuildTarget namedBuildTarget = EditorUtils.GetCurrentNamedBuildTarget();
+            List<string> symbols = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget).Split(';').ToList();
 
             if (symbols.Contains(symbol) == false)
             {
                 symbols.Add(symbol);
-                PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", symbols.ToArray()));
+                PlayerSettings.SetScriptingDefineSymbols(namedBuildTarget, string.Join(";", symbols.ToArray()));
             }
         }
 
         private static void RemoveSymbol(string symbol)
         {
-            BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
-            BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
-            List<string> symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';').ToList();
+            NamedBuildTarget namedBuildTarget = EditorUtils.GetCurrentNamedBuildTarget();
+            List<string> symbols = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget).Split(';').ToList();
 
             if (symbols.Contains(symbol))
             {
                 symbols.Remove(symbol);
-                PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", symbols.ToArray()));
+                PlayerSettings.SetScriptingDefineSymbols(namedBuildTarget, string.Join(";", symbols.ToArray()));
             }
         }
     }

--- a/Source/Core/Editor/Unity/DotNetWindow.cs
+++ b/Source/Core/Editor/Unity/DotNetWindow.cs
@@ -3,67 +3,67 @@
 // Modifications copyright (c) 2021-2024 MindPort GmbH
 
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEngine;
 
- namespace VRBuilder.Editor
- {
-     /// <summary>
-     /// Modal Window that helps setting the 'API Compatibility Level' to '.Net 4.x'.
-     /// </summary>
-     internal class DotNetWindow : EditorWindow
-     {
-         private bool abortBuilding;
-         private BuildTargetGroup buildTargetGroup;
-         private ApiCompatibilityLevel currentLevel;
-         private readonly Vector2 fixedSize = new Vector2(400f, 160);
+namespace VRBuilder.Editor
+{
+    /// <summary>
+    /// Modal Window that helps setting the 'API Compatibility Level' to '.Net 4.x'.
+    /// </summary>
+    internal class DotNetWindow : EditorWindow
+    {
+        private bool abortBuilding;
+        private NamedBuildTarget namedBuildTarget;
+        private ApiCompatibilityLevel currentLevel;
+        private readonly Vector2 fixedSize = new Vector2(400f, 160);
 
-         public bool ShouldAbortBuilding()
-         {
-             return abortBuilding;
-         }
+        public bool ShouldAbortBuilding()
+        {
+            return abortBuilding;
+        }
 
-         private void OnEnable()
-         {
-             abortBuilding = false;
-             minSize = maxSize = fixedSize;
-             titleContent = new GUIContent("API Compatibility Level*");
+        private void OnEnable()
+        {
+            abortBuilding = false;
+            minSize = maxSize = fixedSize;
+            titleContent = new GUIContent("API Compatibility Level*");
 
-             GatherCurrentSettings();
-         }
+            GatherCurrentSettings();
+        }
 
-         private void OnGUI()
-         {
-             EditorGUILayout.Space();
-             EditorGUILayout.HelpBox($"This Unity project uses {currentLevel} but some features require .NET 4.X support.\n\nThe built application might not work as expected.", MessageType.Warning);
-             EditorGUILayout.Space(20f);
-             EditorGUILayout.BeginHorizontal();
-             GUILayout.FlexibleSpace();
-             {
-                 if (GUILayout.Button(EditorGUIUtility.TrTextContent("Fix & Continue", "Sets the 'API Compatibility Level' to '.Net 4.x' and continues building the application."), GUILayout.Width(110f)))
-                 {
-                     PlayerSettings.SetApiCompatibilityLevel(buildTargetGroup, ApiCompatibilityLevel.NET_4_6);
-                     Close();
-                 }
+        private void OnGUI()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox($"This Unity project uses {currentLevel} but some features require .NET 4.X support.\n\nThe built application might not work as expected.", MessageType.Warning);
+            EditorGUILayout.Space(20f);
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            {
+                if (GUILayout.Button(EditorGUIUtility.TrTextContent("Fix & Continue", "Sets the 'API Compatibility Level' to '.Net 4.x' and continues building the application."), GUILayout.Width(110f)))
+                {
+                    PlayerSettings.SetApiCompatibilityLevel(namedBuildTarget, ApiCompatibilityLevel.NET_Unity_4_8);
+                    Close();
+                }
 
-                 if (GUILayout.Button(EditorGUIUtility.TrTextContent("Ignore", "Ignores this warning and continues building the application."), GUILayout.Width(110f)))
-                 {
-                     Close();
-                 }
+                if (GUILayout.Button(EditorGUIUtility.TrTextContent("Ignore", "Ignores this warning and continues building the application."), GUILayout.Width(110f)))
+                {
+                    Close();
+                }
 
-                 if (GUILayout.Button(EditorGUIUtility.TrTextContent("Abort", "Aborts the build immediately."), GUILayout.Width(110f)))
-                 {
-                     abortBuilding = true;
-                     Close();
-                 }
-             }
-             EditorGUILayout.EndHorizontal();
-         }
+                if (GUILayout.Button(EditorGUIUtility.TrTextContent("Abort", "Aborts the build immediately."), GUILayout.Width(110f)))
+                {
+                    abortBuilding = true;
+                    Close();
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+        }
 
-         private void GatherCurrentSettings()
-         {
-             BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
-             buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
-             currentLevel = PlayerSettings.GetApiCompatibilityLevel(buildTargetGroup);
-         }
-     }
- }
+        private void GatherCurrentSettings()
+        {
+            namedBuildTarget = EditorUtils.GetCurrentNamedBuildTarget();
+            currentLevel = PlayerSettings.GetApiCompatibilityLevel(namedBuildTarget);
+        }
+    }
+}

--- a/Source/Core/Editor/Unity/PreBuildDotNetChecker.cs
+++ b/Source/Core/Editor/Unity/PreBuildDotNetChecker.cs
@@ -20,7 +20,7 @@ namespace VRBuilder.Editor
         ///<inheritdoc />
         public void OnPreprocessBuild(BuildReport report)
         {
-            if (EditorUtils.GetCurrentCompatibilityLevel() != ApiCompatibilityLevel.NET_4_6)
+            if (EditorUtils.GetCurrentCompatibilityLevel() != ApiCompatibilityLevel.NET_Unity_4_8)
             {
                 DotNetWindow dotnet = ScriptableObject.CreateInstance<DotNetWindow>();
                 dotnet.ShowModalUtility();
@@ -35,7 +35,7 @@ namespace VRBuilder.Editor
         ///<inheritdoc />
         public void OnPostprocessBuild(BuildReport report)
         {
-            if (EditorUtils.GetCurrentCompatibilityLevel() != ApiCompatibilityLevel.NET_4_6)
+            if (EditorUtils.GetCurrentCompatibilityLevel() != ApiCompatibilityLevel.NET_Unity_4_8)
             {
                 Debug.LogError("This Unity project uses {currentLevel} but some VR Builder features require .NET 4.X support.\nThe built application might not work as expected."
                                + "\nIn order to prevent this, go to Edit > Project Settings > Player Settings > Other Settings and set the Api Compatibility Level to .NET 4.X.");

--- a/Source/Core/Runtime/Configuration/DefaultRuntimeConfiguration.cs
+++ b/Source/Core/Runtime/Configuration/DefaultRuntimeConfiguration.cs
@@ -82,7 +82,7 @@ namespace VRBuilder.Core.Configuration
         }
 
         /// <inheritdoc />
-        public override IEnumerable<UserSceneObject> Users => GameObject.FindObjectsOfType<UserSceneObject>();
+        public override IEnumerable<UserSceneObject> Users => GameObject.FindObjectsByType<UserSceneObject>(FindObjectsSortMode.None);
 
         /// <inheritdoc />
         public override ISceneObjectManager SceneObjectManager

--- a/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
+++ b/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
@@ -60,7 +60,7 @@ namespace VRBuilder.Core.Configuration
         /// <returns>An array of RuntimeConfigurator instances found in the scene.</returns>
         private static RuntimeConfigurator[] LookUpRuntimeConfiguratorGameObjects()
         {
-            RuntimeConfigurator[] instances = FindObjectsOfType<RuntimeConfigurator>();
+            RuntimeConfigurator[] instances = FindObjectsByType<RuntimeConfigurator>(FindObjectsSortMode.None);
 
             return instances;
         }

--- a/Source/Core/Runtime/Unity/UnitySceneSingleton.cs
+++ b/Source/Core/Runtime/Unity/UnitySceneSingleton.cs
@@ -59,7 +59,7 @@ namespace VRBuilder.Unity
                 {
                     if (instance == null)
                     {
-                        instance = (T)FindObjectOfType(ConcreteType);
+                        instance = (T)FindFirstObjectByType(ConcreteType);
                     }
 
                     if (instance == null)
@@ -94,7 +94,7 @@ namespace VRBuilder.Unity
             // Make sure to assign the instance on awake.
             if (instance == null)
             {
-                instance = (T) this;
+                instance = (T)this;
             }
             else
             {


### PR DESCRIPTION
With this change VR Builder not work with Unity versions below Unity 6 as this is whet we decided.
If we retroactively want this we need to add defines `#if UNITY_6000_0_OR_NEWER` and add in all places and add the old code back.

- Updated movingRigidbody.velocity to movingRigidbody.linearVelocity
- Fixed several obsolete API call warnings and added EditroUtils.NamedBuildTarget
