### PR TITLE
If a condition is a lockable property provider, lockable properties are retrieved using the condition's API instead of a helper method

### DIFF
--- a/Source/Core/Runtime/Properties/PropertyReflectionHelper.cs
+++ b/Source/Core/Runtime/Properties/PropertyReflectionHelper.cs
@@ -36,7 +36,14 @@ namespace VRBuilder.Core
             {
                 foreach (ICondition condition in transition.Data.Conditions)
                 {
-                    result.AddRange(ExtractLockablePropertiesFromCondition(condition.Data));
+                    if (condition is ILockablePropertiesProvider lockablePropertiesProvider)
+                    {
+                        result.AddRange(lockablePropertiesProvider.GetLockableProperties());
+                    }
+                    else
+                    {
+                        result.AddRange(ExtractLockablePropertiesFromCondition(condition.Data));
+                    }
                 }
             }
 


### PR DESCRIPTION
The logic is exactly the same, but this allows us or users to override the GetLockableProperties method for custom use cases.