### PR TITLE
Default raycast and interaction layers for teleport is now Teleport on index 31

### DIFF
--- a/Demo/Editor/DemoSceneLoader.cs
+++ b/Demo/Editor/DemoSceneLoader.cs
@@ -50,7 +50,7 @@ namespace VRBuilder.Editor.DemoScene
                 VRBuilder.Core.Setup.ILayerConfigurator configurator = configuratorGameObject.GetComponent<VRBuilder.Core.Setup.ILayerConfigurator>();
                 if (configurator.LayerSet == VRBuilder.Core.Setup.LayerSet.Teleportation)
                 {
-                    configurator.ConfigureLayers("XR Teleport", "XR Teleport");
+                    configurator.ConfigureLayers("Teleport", "Teleport");
                     EditorUtility.SetDirty(configuratorGameObject);
                 }
             }

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/PlayAudioBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/PlayAudioBehavior.cs
@@ -140,6 +140,28 @@ namespace VRBuilder.Core.Behaviors
             }
         }
 
+        private class AbortingProcess : InstantProcess<PlayAudioBehavior.EntityData>
+        {
+            public AbortingProcess(EntityData data) : base(data)
+            {
+            }
+
+            public override void Start()
+            {
+                Debug.Log("Aborting");
+                if (Data.AudioPlayer != null)
+                {
+                    Data.AudioPlayer.Stop();
+                }
+                else
+                {
+                    IProcessAudioPlayer audioPlayer = RuntimeConfigurator.Configuration.ProcessAudioPlayer;
+                    audioPlayer.Stop();
+                    audioPlayer.Reset();
+                }
+            }
+        }
+
         [JsonConstructor, Preserve]
         protected PlayAudioBehavior() : this(null, BehaviorExecutionStages.None)
         {
@@ -168,6 +190,11 @@ namespace VRBuilder.Core.Behaviors
         public override IStageProcess GetDeactivatingProcess()
         {
             return new PlayAudioProcess(BehaviorExecutionStages.Deactivation, Data);
+        }
+
+        public override IStageProcess GetAbortingProcess()
+        {
+            return new AbortingProcess(Data);
         }
     }
 }

--- a/Source/Basic-Interaction-Component/Editor/RigSetup/DefaultRigSceneSetup.cs
+++ b/Source/Basic-Interaction-Component/Editor/RigSetup/DefaultRigSceneSetup.cs
@@ -46,7 +46,7 @@ namespace VRBuilder.Editor.BasicInteraction.RigSetup
                 switch (layerConfigurator.LayerSet)
                 {
                     case LayerSet.Teleportation:
-                        layerConfigurator.ConfigureLayers("XR Teleport", "XR Teleport");
+                        layerConfigurator.ConfigureLayers("Teleport", "Teleport");
                         break;
                     default:
                         break;

--- a/Source/Core/Editor/UI/Wizard/Setup/AllAboutPage.cs
+++ b/Source/Core/Editor/UI/Wizard/Setup/AllAboutPage.cs
@@ -80,7 +80,7 @@ namespace VRBuilder.Editor.UI.Wizard
                 ILayerConfigurator configurator = configuratorGameObject.GetComponent<ILayerConfigurator>();
                 if (configurator.LayerSet == LayerSet.Teleportation)
                 {
-                    configurator.ConfigureLayers("XR Teleport", "XR Teleport");
+                    configurator.ConfigureLayers("Teleport", "Teleport");
                     EditorUtility.SetDirty(configuratorGameObject);
                 }
             }

--- a/Source/Package-Manager/PackageDependencies/PostProcessingPackageEnabler.cs
+++ b/Source/Package-Manager/PackageDependencies/PostProcessingPackageEnabler.cs
@@ -12,6 +12,6 @@ namespace VRBuilder.Editor.PackageManager
         public override int Priority { get; } = 10;
 
         /// <inheritdoc/>
-        protected override string[] Layers { get; } = { "Post-Processing" };
+        protected override LayerDependency[] LayerDependencies { get; } = { new LayerDependency("Post-Processing") };
     }
 }

--- a/Source/Package-Manager/PackageManager/Dependency.cs
+++ b/Source/Package-Manager/PackageManager/Dependency.cs
@@ -3,11 +3,11 @@
 // Modifications copyright (c) 2021-2024 MindPort GmbH
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using UnityEngine;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.PackageManager.UI;
+using UnityEngine;
 
 namespace VRBuilder.Editor.PackageManager
 {
@@ -37,10 +37,13 @@ namespace VRBuilder.Editor.PackageManager
         /// </summary>
         public virtual string[] Samples { get; } = null;
 
+        [Obsolete("Use LayerDependencies instead.")]
+        protected virtual string[] Layers { get; } = null;
+
         /// <summary>
         /// A list of layers to be added.
         /// </summary>
-        protected virtual string[] Layers { get; } = null;
+        protected virtual LayerDependency[] LayerDependencies { get; } = null;
 
         /// <summary>
         /// Emitted when this <see cref="Dependency"/> is set as enabled.
@@ -120,9 +123,9 @@ namespace VRBuilder.Editor.PackageManager
 
         private void AddMissingLayers()
         {
-            if (Layers != null)
+            if (LayerDependencies != null)
             {
-                LayerUtils.AddLayers(Layers);
+                LayerUtils.AddLayerDependencies(LayerDependencies);
             }
         }
     }

--- a/Source/Package-Manager/PackageManager/LayerDependency.cs
+++ b/Source/Package-Manager/PackageManager/LayerDependency.cs
@@ -1,0 +1,24 @@
+namespace VRBuilder.Editor.PackageManager
+{
+    /// <summary>
+    /// A layer to be created by a <see cref="Dependency"/>.
+    /// </summary>
+    public struct LayerDependency
+    {
+        /// <summary>
+        /// The name of the layer to be created.
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// The preferred position in the array for the layer.
+        /// </summary>
+        public readonly int PreferredPosition;
+
+        public LayerDependency(string name, int preferredPosition = -1)
+        {
+            Name = name;
+            PreferredPosition = preferredPosition;
+        }
+    }
+}

--- a/Source/Package-Manager/PackageManager/LayerDependency.cs.meta
+++ b/Source/Package-Manager/PackageManager/LayerDependency.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cf8f402a1deca245916f08976100333
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Package-Manager/PackageManager/LayerUtils.cs
+++ b/Source/Package-Manager/PackageManager/LayerUtils.cs
@@ -51,7 +51,7 @@ namespace VRBuilder.Editor.PackageManager
                 // First 8 slots are reserved by Unity.
                 else if (layerDependency.PreferredPosition < 8)
                 {
-                    //TODO exception
+                    throw new IndexOutOfRangeException($"Unable to create layer '{layerDependency.Name}' at position {layerDependency.PreferredPosition}. Layers 0-7 are reserved by Unity.");
                 }
                 else if (layerDependency.PreferredPosition < layersField.arraySize)
                 {
@@ -68,7 +68,7 @@ namespace VRBuilder.Editor.PackageManager
                 }
                 else
                 {
-                    //TODO exception
+                    throw new IndexOutOfRangeException($"Unable to create layer '{layerDependency.Name}' at position {layerDependency.PreferredPosition}. Requested index is out of range.");
                 }
             }
 

--- a/Source/Package-Manager/PackageManager/LayerUtils.cs
+++ b/Source/Package-Manager/PackageManager/LayerUtils.cs
@@ -89,6 +89,7 @@ namespace VRBuilder.Editor.PackageManager
         /// </summary>
         /// <exception cref="FileLoadException">Exception thrown if the TagManager was not found.</exception>
         /// <exception cref="ArgumentException">Exception thrown if layers field is not found or is not an array.</exception>
+        /// <remarks> The first 8 layers are reserved by Unity and will be ignored.</remarks>
         public static void AddLayers(IEnumerable<string> layers)
         {
             Object[] foundAsset = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset");

--- a/Source/Package-Manager/PackageManager/LayerUtils.cs
+++ b/Source/Package-Manager/PackageManager/LayerUtils.cs
@@ -36,7 +36,6 @@ namespace VRBuilder.Editor.PackageManager
 
             SerializedObject tagManager = new SerializedObject(foundAsset.First());
             SerializedProperty layersField = tagManager.FindProperty("layers");
-            Queue<LayerDependency> newLayers = new Queue<LayerDependency>(layerDependencies);
 
             if (layersField == null || layersField.isArray == false)
             {

--- a/Source/Package-Manager/PackageManager/LayerUtils.cs
+++ b/Source/Package-Manager/PackageManager/LayerUtils.cs
@@ -21,8 +21,68 @@ namespace VRBuilder.Editor.PackageManager
         /// </summary>
         public static void AddLayer(string layer)
         {
-            string[] layers = {layer};
+            string[] layers = { layer };
             AddLayers(layers);
+        }
+
+        public static void AddLayerDependencies(IEnumerable<LayerDependency> layerDependencies)
+        {
+            Object[] foundAsset = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset");
+
+            if (foundAsset.Any() == false)
+            {
+                throw new FileLoadException("There was a problem trying to load ProjectSettings/TagManager.asset");
+            }
+
+            SerializedObject tagManager = new SerializedObject(foundAsset.First());
+            SerializedProperty layersField = tagManager.FindProperty("layers");
+            Queue<LayerDependency> newLayers = new Queue<LayerDependency>(layerDependencies);
+
+            if (layersField == null || layersField.isArray == false)
+            {
+                throw new ArgumentException("Field layers is either null or not array.");
+            }
+
+            foreach (LayerDependency layerDependency in layerDependencies)
+            {
+                if (layerDependency.PreferredPosition < 0)
+                {
+                    AddLayer(layerDependency.Name);
+                }
+                // First 8 slots are reserved by Unity.
+                else if (layerDependency.PreferredPosition < 8)
+                {
+                    //TODO exception
+                }
+                else if (layerDependency.PreferredPosition < layersField.arraySize)
+                {
+                    SerializedProperty serializedProperty = layersField.GetArrayElementAtIndex(layerDependency.PreferredPosition);
+                    string currentLayer = serializedProperty.stringValue;
+
+                    if (currentLayer != layerDependency.Name)
+                    {
+                        if (string.IsNullOrEmpty(currentLayer) || ShowLayerExistsDialog(layerDependency, currentLayer))
+                        {
+                            serializedProperty.stringValue = layerDependency.Name;
+                        }
+                    }
+                }
+                else
+                {
+                    //TODO exception
+                }
+            }
+
+            tagManager.ApplyModifiedProperties();
+        }
+
+        private static bool ShowLayerExistsDialog(LayerDependency layerDependency, string currentLayer)
+        {
+            string title = "Layer position is not empty";
+            string description = $"Attempted to create layer '{layerDependency.Name}' at position {layerDependency.PreferredPosition}. The position is not empty but occupied by layer '{currentLayer}'.";
+            string yes = "Overwrite";
+            string no = "Skip";
+            return EditorUtility.DisplayDialog(title, description, yes, no);
         }
 
         /// <summary>

--- a/Source/XR-Interaction-Component/PackageManager/XRInteractionPackageEnabler.cs
+++ b/Source/XR-Interaction-Component/PackageManager/XRInteractionPackageEnabler.cs
@@ -15,6 +15,6 @@
         public override int Priority { get; } = 4;
 
         /// <inheritdoc/>
-        protected override string[] Layers { get; } = { "XR Teleport" };
+        protected override LayerDependency[] LayerDependencies { get; } = { new LayerDependency("Teleport", 31) };
     }
 }

--- a/Source/XR-Interaction-Component/Source/Editor/Interaction/TeleportationAnchorVRBuilderEditor.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/Interaction/TeleportationAnchorVRBuilderEditor.cs
@@ -14,7 +14,7 @@ namespace VRBuilder.Editor.XRInteraction
     [CustomEditor(typeof(TeleportationAnchorVRBuilder)), CanEditMultipleObjects]
     public class TeleportationAnchorVRBuilderEditor : TeleportationAnchorEditor
     {
-        private const string teleportLayerName = "XR Teleport";
+        private const string teleportLayerName = "Teleport";
         private const string reticlePrefab = "TeleportReticle";
         private const string anchorPrefabName = "VRBuilderAnchorPrefab";
         private const string anchorSceneName = "Anchor";

--- a/Source/XR-Interaction-Component/Source/Editor/Interaction/TeleportationAreaVRBuilderEditor.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/Interaction/TeleportationAreaVRBuilderEditor.cs
@@ -9,7 +9,7 @@ namespace VRBuilder.Editor.XRInteraction
     [CustomEditor(typeof(TeleportationAreaVRBuilder)), CanEditMultipleObjects]
     public class TeleportationAreaVRBuilderEditor : TeleportationAreaEditor
     {
-        private const string teleportLayerName = "XR Teleport";
+        private const string teleportLayerName = "Teleport";
         private const string reticlePrefab = "TeleportReticle";
 
         public override void OnInspectorGUI()

--- a/Source/XR-Interaction-Component/Source/Editor/UI/Menu/ConfigureInteractionLayersMenuEntry.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/UI/Menu/ConfigureInteractionLayersMenuEntry.cs
@@ -11,8 +11,8 @@ namespace VRBuilder.Editor.XRInteraction.Menu
     /// </summary>
     internal static class ConfigureInteractionLayersMenuEntry
     {
-        private const string teleportRaycastLayer = "XR Teleport";
-        private const string teleportInteractionLayer = "XR Teleport";
+        private const string teleportRaycastLayer = "Teleport";
+        private const string teleportInteractionLayer = "Teleport";
 
         [MenuItem("Tools/VR Builder/Developer/Configure Teleportation Layers", false, 80)]
         private static void ConfigureTeleportationLayers()

--- a/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
@@ -16,7 +16,7 @@ namespace VRBuilder.Editor.XRInteraction
         /// </summary>
         internal static string[] DefaultInteractionLayers =
         {
-            "XR Teleport",
+            "Teleport",
         };
 
         static CreateDefaultInteractionLayers()

--- a/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
@@ -1,4 +1,5 @@
 #if VR_BUILDER_XR_INTERACTION
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using VRBuilder.Editor.XRInteractionExtension;
@@ -14,18 +15,18 @@ namespace VRBuilder.Editor.XRInteraction
         /// <summary>
         /// List of interaction layers that VR Builder creates automatically.
         /// </summary>
-        internal static string[] DefaultInteractionLayers =
+        internal static readonly Dictionary<int, string> DefaultInteractionLayers = new Dictionary<int, string>()
         {
-            "Teleport",
+            {31, "Teleport" }
         };
 
         static CreateDefaultInteractionLayers()
         {
-            foreach (string layer in DefaultInteractionLayers)
+            foreach (int index in DefaultInteractionLayers.Keys)
             {
-                if (InteractionLayerUtils.AddLayerIfNotPresent(layer) == false)
+                if (InteractionLayerUtils.TryAddLayerAtPosition(DefaultInteractionLayers[index], index) == false)
                 {
-                    Debug.LogError($"Interaction layer '{layer}' is not present and it was not possible to add it automatically.");
+                    Debug.LogError($"Interaction layer '{DefaultInteractionLayers[index]}' is not present and it was not possible to add it automatically.");
                 }
             }
         }

--- a/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
+++ b/Source/XR-Interaction-Component/Source/Editor/UI/ProjectSettings/CreateDefaultInteractionLayers.cs
@@ -24,7 +24,7 @@ namespace VRBuilder.Editor.XRInteraction
         {
             foreach (int index in DefaultInteractionLayers.Keys)
             {
-                if (InteractionLayerUtils.TryAddLayerAtPosition(DefaultInteractionLayers[index], index) == false)
+                if (InteractionLayerUtils.AddLayerIfNotPresent(DefaultInteractionLayers[index], false, index) == false)
                 {
                     Debug.LogError($"Interaction layer '{DefaultInteractionLayers[index]}' is not present and it was not possible to add it automatically.");
                 }

--- a/Source/XR-Interaction-Component/Source/XRInteractionExtension/Editor/InteractionLayerUtils.cs
+++ b/Source/XR-Interaction-Component/Source/XRInteractionExtension/Editor/InteractionLayerUtils.cs
@@ -15,10 +15,10 @@ namespace VRBuilder.Editor.XRInteractionExtension
         /// <param name="layerName">Name of the layer to add.</param>
         /// <param name="showDialog">If true, a dialog will be shown for user confirmation.</param>
         /// <returns>True if the layer has been added or was already present.</returns>
-        public static bool AddLayerIfNotPresent(string layerName, bool showDialog = false)
+        public static bool AddLayerIfNotPresent(string layerName, bool showDialog = false, int preferredPosition = -1)
         {
             string dialogTitle = "Add interaction layer?";
-            string dialogText = $"The required interaction layer '{layerName}' has not been found. Do you want to create it at the first available position?";
+            string dialogText = $"The required interaction layer '{layerName}' has not been found. Do you want to create it?";
             string dialogConfirm = "Yes";
             string dialogCancel = "No";
 
@@ -29,7 +29,7 @@ namespace VRBuilder.Editor.XRInteractionExtension
 
             if (showDialog == false || EditorUtility.DisplayDialog(dialogTitle, dialogText, dialogConfirm, dialogCancel))
             {
-                return AddLayer(layerName);
+                return TryAddLayerAtPosition(layerName, preferredPosition);
             }
 
             return false;
@@ -77,13 +77,16 @@ namespace VRBuilder.Editor.XRInteractionExtension
             SerializedObject interactionLayerSettingsSo = new SerializedObject(InteractionLayerSettings.Instance);
             SerializedProperty layerNamesProperty = interactionLayerSettingsSo.FindProperty(layerNamesPropertyPath);
 
-            SerializedProperty interactionLayerNameProperty = layerNamesProperty.GetArrayElementAtIndex(preferredPosition);
-
-            if (interactionLayerNameProperty.stringValue == null || string.IsNullOrEmpty(interactionLayerNameProperty.stringValue))
+            if (preferredPosition >= InteractionLayerSettings.builtInLayerSize && preferredPosition < InteractionLayerSettings.layerSize)
             {
-                interactionLayerNameProperty.stringValue = layerName;
-                interactionLayerSettingsSo.ApplyModifiedProperties();
-                return true;
+                SerializedProperty interactionLayerNameProperty = layerNamesProperty.GetArrayElementAtIndex(preferredPosition);
+
+                if (interactionLayerNameProperty.stringValue == null || string.IsNullOrEmpty(interactionLayerNameProperty.stringValue))
+                {
+                    interactionLayerNameProperty.stringValue = layerName;
+                    interactionLayerSettingsSo.ApplyModifiedProperties();
+                    return true;
+                }
             }
 
             return AddLayer(layerName);

--- a/Source/XR-Interaction-Component/Source/XRInteractionExtension/Editor/InteractionLayerUtils.cs
+++ b/Source/XR-Interaction-Component/Source/XRInteractionExtension/Editor/InteractionLayerUtils.cs
@@ -62,6 +62,32 @@ namespace VRBuilder.Editor.XRInteractionExtension
 
             return false;
         }
+
+        /// <summary>
+        /// Tries to add a layer at a specified position. If the position is already occupied,
+        /// tries to add it on the first available spot.
+        /// </summary>
+        /// <param name="layerName">Name of the layer to add.</param>
+        /// <param name="preferredPosition">Preferred index in the interaction layers array.</param>
+        /// <returns>True if a layer was added.</returns>
+        public static bool TryAddLayerAtPosition(string layerName, int preferredPosition)
+        {
+            const string layerNamesPropertyPath = "m_LayerNames";
+
+            SerializedObject interactionLayerSettingsSo = new SerializedObject(InteractionLayerSettings.Instance);
+            SerializedProperty layerNamesProperty = interactionLayerSettingsSo.FindProperty(layerNamesPropertyPath);
+
+            SerializedProperty interactionLayerNameProperty = layerNamesProperty.GetArrayElementAtIndex(preferredPosition);
+
+            if (interactionLayerNameProperty.stringValue == null || string.IsNullOrEmpty(interactionLayerNameProperty.stringValue))
+            {
+                interactionLayerNameProperty.stringValue = layerName;
+                interactionLayerSettingsSo.ApplyModifiedProperties();
+                return true;
+            }
+
+            return AddLayer(layerName);
+        }
     }
 }
 #endif

--- a/Source/XR-Interaction-Component/StaticAssets/Prefabs/Interactors/Left Teleport Interactor.prefab
+++ b/Source/XR-Interaction-Component/StaticAssets/Prefabs/Interactors/Left Teleport Interactor.prefab
@@ -50,7 +50,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_InteractionManager: {fileID: 0}
   m_InteractionLayers:
-    m_Bits: 2
+    m_Bits: 2147483648
   m_Handedness: 1
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 0
@@ -187,7 +187,7 @@ MonoBehaviour:
   m_ConeCastAngle: 6
   m_RaycastMask:
     serializedVersion: 2
-    m_Bits: 256
+    m_Bits: 2147483648
   m_RaycastTriggerInteraction: 1
   m_RaycastSnapVolumeInteraction: 1
   m_HitClosestOnly: 0

--- a/Source/XR-Interaction-Component/StaticAssets/Resources/VRB_XR_Setup.prefab
+++ b/Source/XR-Interaction-Component/StaticAssets/Resources/VRB_XR_Setup.prefab
@@ -212,6 +212,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: XRI Rig
       objectReference: {fileID: 0}
+    - target: {fileID: 3573058871122886203, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
+      propertyPath: m_RaycastMask.m_Bits
+      value: 2147483904
+      objectReference: {fileID: 0}
+    - target: {fileID: 3573058871122886203, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
+      propertyPath: m_InteractionLayers.m_Bits
+      value: 2147483648
+      objectReference: {fileID: 0}
     - target: {fileID: 6578433699197303339, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -251,6 +259,14 @@ PrefabInstance:
     - target: {fileID: 6578433699197303339, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7086510513979687868, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
+      propertyPath: m_RaycastMask.m_Bits
+      value: 2147483904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7086510513979687868, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
+      propertyPath: m_InteractionLayers.m_Bits
+      value: 2147483648
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Source/XR-Interaction-Component/StaticAssets/Resources/VRB_XR_Setup.prefab
+++ b/Source/XR-Interaction-Component/StaticAssets/Resources/VRB_XR_Setup.prefab
@@ -212,14 +212,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: XRI Rig
       objectReference: {fileID: 0}
-    - target: {fileID: 3573058871122886203, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
-      propertyPath: m_RaycastMask.m_Bits
-      value: 2147483904
-      objectReference: {fileID: 0}
-    - target: {fileID: 3573058871122886203, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
-      propertyPath: m_InteractionLayers.m_Bits
-      value: 2147483648
-      objectReference: {fileID: 0}
     - target: {fileID: 6578433699197303339, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -259,14 +251,6 @@ PrefabInstance:
     - target: {fileID: 6578433699197303339, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7086510513979687868, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
-      propertyPath: m_RaycastMask.m_Bits
-      value: 2147483904
-      objectReference: {fileID: 0}
-    - target: {fileID: 7086510513979687868, guid: 550ca5f5c17e3564ab1d38eaad81efce, type: 3}
-      propertyPath: m_InteractionLayers.m_Bits
-      value: 2147483648
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
- Dependencies now provide a list of `LayerDependency` instead of a list of strings. LayerDependencies can contain a preferred index and possibly other parameters.
- All hardcoded "XR Teleport" layer names changed to "Teleport".
- Interaction layers can also be created at a preferred index.