### PR TITLE
Fix for object not grabbable if not set touchable as well

### DIFF
--- a/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
@@ -140,7 +140,7 @@ namespace VRBuilder.XRInteraction.Interactables
         /// <remarks>It always returns false when <see cref="IsTouchable"/> is false.</remarks>
         public override bool IsHoverableBy(IXRHoverInteractor interactor)
         {
-            return isTouchable && base.IsHoverableBy(interactor);
+            return (isTouchable || isGrabbable) && base.IsHoverableBy(interactor);
         }
 
         /// <summary>

--- a/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
@@ -137,7 +137,6 @@ namespace VRBuilder.XRInteraction.Interactables
         /// </summary>
         /// <param name="interactor">Interactor to check for a valid hover state with.</param>
         /// <returns>True if hovering is valid this frame, False if not.</returns>
-        /// <remarks>It always returns false when <see cref="IsTouchable"/> is false.</remarks>
         public override bool IsHoverableBy(IXRHoverInteractor interactor)
         {
             return (isTouchable || isGrabbable) && base.IsHoverableBy(interactor);


### PR DESCRIPTION
You need to be able to hover an object in order to grab it. The InteractableObject returned an object as hoverable only if it's touchable. Since now we assess touch by checking for a specific interactor, this can return true also when isTouchable is set to false.