### PR TITLE
Fix for exception when applying new group to multiple prefabs

### DIFF
--- a/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
@@ -254,6 +254,11 @@ namespace VRBuilder.Core.Editor.UI
                 Undo.RecordObject((UnityEngine.Object)container, "Added group");
                 container.AddGuid(group.Guid);
             }
+
+            foreach (UnityEngine.Object unityObject in groupContainers.Where(container => container is UnityEngine.Object).Cast<UnityEngine.Object>())
+            {
+                EditorUtility.SetDirty(unityObject);
+            }
         }
 
         private static void EvaluateNewGroupName(string newGroup, Button addNewGroupButton)


### PR DESCRIPTION
To repro:
- Create 2+ PSO prefabs and add them to the scene
- Select them all and assign them a group with the "create new group" button.
- Press play
- Exception happens.

Solution:
Objects are now set dirty after applying all groups.