### PR TITLE
Fixed obsolete warnings related to XRI 3.0

### DIFF
--- a/Source/XRInteraction/Source/Editor/UI/Inspector/TeleportationAnchorVRBuilderEditor.cs
+++ b/Source/XRInteraction/Source/Editor/UI/Inspector/TeleportationAnchorVRBuilderEditor.cs
@@ -91,7 +91,10 @@ namespace VRBuilder.XRInteraction.Editor.UI.Inspector
         {
             CreateChildObject(teleportationAnchor, interactionAffordancePrefabName, interactionAffordanceSceneName, (affordancePrefab) =>
             {
+                //TODO fix that state provider if unity adds the new implementation
+                #pragma warning disable CS0618 // Type or member is obsolete
                 affordancePrefab.GetComponent<XRInteractableAffordanceStateProvider>().interactableSource = teleportationAnchor;
+                #pragma warning restore CS0618 // Type or member is obsolete
             });
         }
 

--- a/Source/XRInteraction/Source/Runtime/Locomotion/RigManipulationProvider.cs
+++ b/Source/XRInteraction/Source/Runtime/Locomotion/RigManipulationProvider.cs
@@ -16,12 +16,12 @@ namespace VRBuilder.XRInteraction.Locomotion
         /// <param name="destinationRotation">Target rotation.</param>
         public void SetRigPositionAndRotation(Vector3 destinationPosition, Quaternion destinationRotation)
         {
-            if (CanBeginLocomotion() == false)
+            if (isLocomotionActive == false)
             {
                 return;
             }
 
-            XROrigin xrOrigin = system.xrOrigin;
+            XROrigin xrOrigin = mediator.xrOrigin;
 
             if (xrOrigin != null)
             {

--- a/Source/XRInteraction/Source/Runtime/Locomotion/XRLocomotionHandler.cs
+++ b/Source/XRInteraction/Source/Runtime/Locomotion/XRLocomotionHandler.cs
@@ -14,12 +14,12 @@ namespace VRBuilder.XRInteraction.Locomotion
         /// <summary>
         /// Current rotation of the XR Rig.
         /// </summary>
-        public override Quaternion CurrentRotation => RigManipulationProvider.system.xrOrigin.transform.rotation;
+        public override Quaternion CurrentRotation => RigManipulationProvider.mediator.xrOrigin.transform.rotation;
 
         /// <summary>
         /// Current position of the XR Rig.
         /// </summary>
-        public override Vector3 CurrentPosition => RigManipulationProvider.system.xrOrigin.transform.position;
+        public override Vector3 CurrentPosition => RigManipulationProvider.mediator.xrOrigin.transform.position;
 
         /// <summary>
         /// Locomotion provider to directly manipulate the XR Rig.


### PR DESCRIPTION
I fixed 4 of 5 obsolete warnings related to XRI 3.0. 

The "affordance state provider system" has currently no updated version according to https://discussions.unity.com/t/demoscene-in-xr-interaction-toolkit-3-0-3/947731 