### PR TITLE
Fixed filtering for label groups

### DIFF
--- a/Source/Core/Editor/UI/GraphView/Windows/SearchableGroupListPopup.cs
+++ b/Source/Core/Editor/UI/GraphView/Windows/SearchableGroupListPopup.cs
@@ -221,7 +221,7 @@ namespace VRBuilder.Core.Editor.UI.GraphView.Windows
 
             foreach (VisualElement child in scrollView.Children())
             {
-                if (child.Q<Label>("Label") is Label label)
+                if (child.Q<Label>("Name") is { } label)
                 {
                     bool isMatch = true;
                     if (searchParts.Length > 0)


### PR DESCRIPTION
I updated the filter function according to the new UQueryExtensions https://docs.unity3d.com/ScriptReference/UIElements.UQueryExtensions.Q.html

The filtering works again with correct string compare.