### PR TITLE
Move refresh registry check out of process scene object class

### DIFF
--- a/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
+++ b/Source/Core/Editor/UI/ProcessSceneObjectEditor.cs
@@ -60,7 +60,10 @@ namespace VRBuilder.Core.Editor.UI
 
         private void OnUniqueIdChanged(object sender, UniqueIdChangedEventArgs e)
         {
-            DisplayObjectGuid(objectIdLabel);
+            if (objectIdLabel != null)
+            {
+                DisplayObjectGuid(objectIdLabel);
+            }
         }
 
         public override VisualElement CreateInspectorGUI()
@@ -276,7 +279,7 @@ namespace VRBuilder.Core.Editor.UI
             bool isPreviewInContext = AssetUtility.IsInPreviewContext(((ProcessSceneObject)target).gameObject);
             IEnumerable<ISceneObject> referencedSceneObjects = RuntimeConfigurator.Configuration?.SceneObjectRegistry?.GetObjects(group.Guid);
 
-            GroupListItem.FillGroupListItem(groupListElement, group.Label, isPreviewInContext: isPreviewInContext, 
+            GroupListItem.FillGroupListItem(groupListElement, group.Label, isPreviewInContext: isPreviewInContext,
                 referencedSceneObjects: referencedSceneObjects, elementIsUniqueIdDisplayName: elementIsUniqueIdDisplayName);
 
             VisualElement removableGroupContainer = removableGroupListItem.Q<VisualElement>("RemovableGroupContainer");

--- a/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
+++ b/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
@@ -74,7 +74,7 @@ namespace VRBuilder.Core.Configuration
         /// <remarks>
         /// This currently triggers a full refresh of the SceneObjectRegistry
         /// </remarks>
-        public static void MarkSceneObjectDirty(object sceneObject)
+        public static void MarkSceneObjectDirty(ProcessSceneObject sceneObject)
         {
             //TODO Keep track of all changed prefabs in a separate class ot the SceneObjectRegistry and only update those
             hasDirtySceneObjects = true;

--- a/Source/Core/Runtime/SceneObjects/GuidBasedSceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/GuidBasedSceneObjectRegistry.cs
@@ -86,7 +86,15 @@ namespace VRBuilder.Core.SceneObjects
                         key = guid.ToString();
                     }
 
-                    Debug.LogError($"Null objects found in scene object registry for key {key}: {registeredObjects[guid].Where(obj => obj.Equals(null)).Count()} object.");
+                    // This happens if we remove a SceneObject from component where no registry is available
+                    // e.g.: From a prefab in prefab edit mode
+                    Debug.LogError($"Null objects found in scene object registry for with Guid {key}: " +
+                        $"{registeredObjects[guid].Where(obj => obj.Equals(null)).Count()} object. " +
+                        $"Most likely you removed a process scene object from a prefab in prefab edit mode. " +
+                        $"Removing the reference it from the registry.");
+
+                    registeredObjects.Remove(guid);
+                    return new List<ISceneObject>();
                 }
 
                 return registeredObjects[guid].Where(obj => obj.Equals(null) == false);

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -1,4 +1,4 @@
-/// Guid based Reference copyright © 2018 Unity Technologies ApS
+/// Guid based Reference copyright 2018 Unity Technologies ApS
 /// Licensed under the Unity Companion License for Unity-dependent projects--see 
 /// Unity Companion License http://www.unity3d.com/legal/licenses/Unity_Companion_License.
 /// Unless expressly provided otherwise, the Software under this license is made available strictly on an 
@@ -17,9 +17,7 @@ using VRBuilder.Core.Utils.Logging;
 
 #if UNITY_EDITOR
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using VRBuilder.Unity;
-
 #endif
 
 namespace VRBuilder.Core.SceneObjects
@@ -90,21 +88,6 @@ namespace VRBuilder.Core.SceneObjects
         /// <inheritdoc />
         public bool IsLocked { get; private set; }
 
-        /// <summary>
-        /// Tracks state swishes prefab edit mode and the main scene.
-        /// </summary>
-        /// <remarks>
-        /// Needs to be static to keep track of the state between different instances of ProcessSceneObject
-        /// </remarks>
-        private static bool hasDirtySceneObject = false;
-        /// <summary>
-        /// Tracks the warning log if the RuntimeConfigurator does not exist
-        /// </summary>
-        /// <remarks>
-        /// This can be removed if the CheckRefreshRegistry is not called in update function anymore
-        /// </remarks>
-        private bool loggedWarning = false;
-
         public event EventHandler<LockStateChangedEventArgs> Locked;
         public event EventHandler<LockStateChangedEventArgs> Unlocked;
         public event EventHandler<GuidContainerEventArgs> GuidAdded;
@@ -126,14 +109,6 @@ namespace VRBuilder.Core.SceneObjects
             }
         }
 
-        private void Update()
-        {
-#if UNITY_EDITOR
-            // TODO We need to move this to another update e.g. something in the RuntimeConfigurator
-            CheckRefreshRegistry();
-#endif
-        }
-
         private void OnValidate()
         {
 #if UNITY_EDITOR
@@ -141,8 +116,11 @@ namespace VRBuilder.Core.SceneObjects
             if (!IsInTheScene())
             {
                 // This catches all cases adding, removing, creating, deleting
-                // It also adds overhead e.g. it is also called when entering prefab edit mode or entering the scene
-                MarkPrefabDirty(this);
+                // But it adds overhead e.g. it is also called when entering prefab edit mode or entering the scene
+                if (RuntimeConfigurator.Exists)
+                {
+                    RuntimeConfigurator.MarkSceneObjectDirty(this);
+                }
                 SetGuidDefaultValues();
             }
 #endif
@@ -284,12 +262,6 @@ namespace VRBuilder.Core.SceneObjects
         /// </summary>
         protected void Init()
         {
-            if (!RuntimeConfigurator.Exists)
-            {
-                LogRuntimeConfigWarning();
-                return;
-            }
-
 #if UNITY_EDITOR
             // if in editor, make sure we aren't a prefab of some kind
             if (!IsInTheScene())
@@ -320,43 +292,6 @@ namespace VRBuilder.Core.SceneObjects
         {
             bool isSceneObject = AssetUtility.IsComponentInScene(this);
             return isSceneObject;
-        }
-
-        /// <summary>
-        /// Refreshes the scene object registry when we have <see cref="hasDirtySceneObject"/> and are in the main scene
-        /// </summary>
-        private bool CheckRefreshRegistry()
-        {
-            if (RuntimeConfigurator.Exists)
-            {
-                bool isMainStage = StageUtility.GetCurrentStageHandle() == StageUtility.GetMainStageHandle();
-
-                if (isMainStage && hasDirtySceneObject)
-                {
-                    RuntimeConfigurator.Configuration?.SceneObjectRegistry?.Refresh();
-                    hasDirtySceneObject = false;
-                    //TODO if we have an open PSO in the Inspector we should redraw it
-                    return true;
-                }
-            }
-            else
-            {
-                LogRuntimeConfigWarning();
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Marks the specified scene object as dirty, indicating that its prefab has been modified outside of the scene.
-        /// </summary>
-        /// <param name="sceneObject">The scene object to mark as dirty.</param>
-        private static void MarkPrefabDirty(ProcessSceneObject sceneObject)
-        {
-            // Potentially keep track of all changed prefabs in a separate class and only update those in the registry
-            // https://chat.openai.com/share/736f3640-b884-4bf3-aabb-01af50e44810
-            //PrefabDirtyTracker.MarkPrefabDirty(sceneObject);
-
-            hasDirtySceneObject = true;
         }
 #endif
 
@@ -523,15 +458,6 @@ namespace VRBuilder.Core.SceneObjects
         public override string ToString()
         {
             return GameObject.name;
-        }
-        
-        private void LogRuntimeConfigWarning()
-        {
-            if (!loggedWarning)
-            {
-                Debug.LogWarning($"Not registering {gameObject.name} due to runtime configurator not present.");
-                loggedWarning = true;
-            }
         }
     }
 }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -130,14 +130,7 @@ namespace VRBuilder.Core.SceneObjects
         {
 #if UNITY_EDITOR
             // TODO We need to move this to another update e.g. something in the RuntimeConfigurator
-            if (CheckRefreshRegistry())
-            {
-                loggedWarning = false;
-            }
-            else if (!loggedWarning)
-            {
-                LogRuntimeConfigWarning();
-            }
+            CheckRefreshRegistry();
 #endif
         }
 
@@ -282,7 +275,7 @@ namespace VRBuilder.Core.SceneObjects
         /// <returns><c>true</c> if the Guid is assigned; otherwise, <c>false</c>.</returns>
         protected bool IsGuidAssigned()
         {
-            return guid != System.Guid.Empty;
+            return guid != Guid.Empty;
         }
 
         /// <summary>
@@ -291,7 +284,7 @@ namespace VRBuilder.Core.SceneObjects
         /// </summary>
         protected void Init()
         {
-            if (RuntimeConfigurator.Exists == false)
+            if (!RuntimeConfigurator.Exists)
             {
                 LogRuntimeConfigWarning();
                 return;
@@ -330,9 +323,9 @@ namespace VRBuilder.Core.SceneObjects
         }
 
         /// <summary>
-        /// Refreshes the scene object registry when we have <see cref="hasDirtySceneObject"/ and are in the main scene>
+        /// Refreshes the scene object registry when we have <see cref="hasDirtySceneObject"/> and are in the main scene
         /// </summary>
-        private static bool CheckRefreshRegistry()
+        private bool CheckRefreshRegistry()
         {
             if (RuntimeConfigurator.Exists)
             {
@@ -345,6 +338,10 @@ namespace VRBuilder.Core.SceneObjects
                     //TODO if we have an open PSO in the Inspector we should redraw it
                     return true;
                 }
+            }
+            else
+            {
+                LogRuntimeConfigWarning();
             }
             return false;
         }
@@ -530,8 +527,11 @@ namespace VRBuilder.Core.SceneObjects
         
         private void LogRuntimeConfigWarning()
         {
-            Debug.LogWarning($"Not registering {gameObject.name} due to runtime configurator not present.");
-            loggedWarning = true;
+            if (!loggedWarning)
+            {
+                Debug.LogWarning($"Not registering {gameObject.name} due to runtime configurator not present.");
+                loggedWarning = true;
+            }
         }
     }
 }

--- a/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
+++ b/Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs
@@ -262,6 +262,11 @@ namespace VRBuilder.Core.SceneObjects
         /// </summary>
         protected void Init()
         {
+            if (!RuntimeConfigurator.Exists)
+            {
+                return;
+            }
+
 #if UNITY_EDITOR
             // if in editor, make sure we aren't a prefab of some kind
             if (!IsInTheScene())


### PR DESCRIPTION
This is base up on feature/mp-3263-bugfix-startup-warnings.

It's important to do some extra prefab workflow Tests and try to break it. What I've already done:
- I did run Tests
- I added an removed groups in prefab mode
- I applied groups to prefabs
- I added a prefab with PSO in a non VR Builder Scene
- I created a PSO in Prefab edit mode
- I reset the the PSO Component
- I applied a PSO to a prefab
- I removed a PSO from a prefab in prefab edit mode which is used in a Behavior. 
  -  This caused a not related Debug.LogError (in GuidBasedSceneObjectRegistry.GetObjects) to be triggernd continuously as long as the Step is open. ![image](https://github.com/user-attachments/assets/c3fc8471-817b-46ac-a8f4-f5734bf3a71a).
  - I fixed it in this ticket.

## AI Generated

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Moved registry refresh logic to `RuntimeConfigurator` for better encapsulation.

- Added `MarkSceneObjectDirty` and `RefreshRegistryIfNeeded` methods in `RuntimeConfigurator`.

- Removed redundant registry refresh logic from `ProcessSceneObject`.

- Improved handling of dirty scene objects and warnings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuntimeConfigurator.cs</strong><dd><code>Added registry refresh logic and dirty object tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Core/Runtime/Configuration/RuntimeConfigurator.cs

<li>Added <code>hasDirtySceneObjects</code> flag and <code>MarkSceneObjectDirty</code> method.<br> <li> Implemented <code>RefreshRegistryIfNeeded</code> method for registry updates.<br> <li> Integrated registry refresh logic into <code>Update</code> method.<br> <li> Added editor-specific logic for handling dirty scene objects.


</details>


  </td>
  <td><a href="https://github.com/MindPort-GmbH/VR-Builder/pull/295/files#diff-be8c71e55a7d5a30a2abb1cd46a1a8fa3035b148ce16e7fbee644941d24e0a29">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProcessSceneObject.cs</strong><dd><code>Removed registry refresh logic and streamlined methods</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Core/Runtime/SceneObjects/ProcessSceneObject.cs

<li>Removed <code>CheckRefreshRegistry</code> and <code>MarkPrefabDirty</code> methods.<br> <li> Delegated dirty object handling to <code>RuntimeConfigurator</code>.<br> <li> Simplified <code>OnValidate</code> and <code>Init</code> methods.<br> <li> Removed redundant warning logging logic.


</details>


  </td>
  <td><a href="https://github.com/MindPort-GmbH/VR-Builder/pull/295/files#diff-b5648d01877914daf5ff40f4f2a1485b97fbb8573b91aadbe0ca00410f1d70c8">+7/-81</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>