### PR TITLE
Fix for Play Animation Clip not working in builds

### DIFF
--- a/Source/Core/Editor/UI/Drawers/AnimationClipResourceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/AnimationClipResourceDrawer.cs
@@ -8,6 +8,9 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     /// </summary>
     public class AnimationClipResourceDrawer : ResourcePathDrawer<AnimationClip>
     {
+        /// <summary>
+        /// Automatically sets the Legacy flag on the clip to true, if it is not already.
+        /// </summary>
         public override void ValidateResource(AnimationClip resource)
         {
             if (resource.legacy == false)

--- a/Source/Core/Editor/UI/Drawers/AnimationClipResourceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/AnimationClipResourceDrawer.cs
@@ -1,3 +1,4 @@
+using UnityEditor;
 using UnityEngine;
 
 namespace VRBuilder.Core.Editor.UI.Drawers
@@ -7,5 +8,14 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     /// </summary>
     public class AnimationClipResourceDrawer : ResourcePathDrawer<AnimationClip>
     {
+        public override void ValidateResource(AnimationClip resource)
+        {
+            if (resource.legacy == false)
+            {
+                resource.legacy = true;
+                EditorUtility.SetDirty(resource);
+                UnityEngine.Debug.Log($"Animation clip '{resource.name}' has been marked as Legacy since it is being used outside of an animator.");
+            }
+        }
     }
 }

--- a/Source/Core/Editor/UI/Drawers/ResourcePathDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/ResourcePathDrawer.cs
@@ -9,14 +9,19 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     /// </summary>
     public abstract class ResourcePathDrawer<T> : AbstractDrawer where T : UnityEngine.Object
     {
+        /// <summary>
+        /// Validates the resource just dragged in the drawer.
+        /// </summary>
+        public abstract void ValidateResource(T resource);
+
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
             string oldPath = currentValue as string;
-            T videoClip = Resources.Load<T>(oldPath);
+            T oldResource = Resources.Load<T>(oldPath);
 
-            videoClip = EditorGUI.ObjectField(rect, label, videoClip, typeof(T), false) as T;
+            T resource = EditorGUI.ObjectField(rect, label, oldResource, typeof(T), false) as T;
 
-            string newPath = AssetDatabase.GetAssetOrScenePath(videoClip);
+            string newPath = AssetDatabase.GetAssetOrScenePath(resource);
 
             if (string.IsNullOrEmpty(newPath) == false)
             {
@@ -34,6 +39,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 {
                     newPath = newPath.Remove(newPath.LastIndexOf("."));
                 }
+            }
+
+            if (resource != null && resource != oldResource && string.IsNullOrEmpty(newPath) == false)
+            {
+                ValidateResource(resource);
             }
 
             if (oldPath != newPath)

--- a/Source/Core/Editor/UI/Drawers/VideoClipResourceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/VideoClipResourceDrawer.cs
@@ -7,5 +7,8 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     /// </summary>
     public class VideoClipResourceDrawer : ResourcePathDrawer<VideoClip>
     {
+        public override void ValidateResource(VideoClip resource)
+        {
+        }
     }
 }

--- a/Source/Core/Editor/UI/Drawers/VideoClipResourceDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/VideoClipResourceDrawer.cs
@@ -7,6 +7,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     /// </summary>
     public class VideoClipResourceDrawer : ResourcePathDrawer<VideoClip>
     {
+        /// <inheritdoc/>
         public override void ValidateResource(VideoClip resource)
         {
         }


### PR DESCRIPTION
- Added a "Validate" function to ResourcePathDrawer. It allows to run some code after a new resource is dragged in the inspector.
- AnimationClipResourceDrawer now uses the Validate function to check if a clip is set to Legacy, and automatically set it if it is not.