### PR TITLE
Added fix for InheritSceneObjectLockState in the UseableProperty

### DIFF
--- a/Source/XRInteraction/Source/Runtime/Properties/UsableProperty.cs
+++ b/Source/XRInteraction/Source/Runtime/Properties/UsableProperty.cs
@@ -61,7 +61,7 @@ namespace VRBuilder.XRInteraction.Properties
 
             if (InheritSceneObjectLockState)
             {
-                IsLocked = GetComponentInParent<ILockable>()?.IsLocked ?? IsLocked;
+                IsLocked = GetComponentInParent<UsableProperty>()?.IsLocked ?? IsLocked;
             }
             
             InternalSetLocked(IsLocked);

--- a/Source/XRInteraction/Source/Runtime/Properties/UsableProperty.cs
+++ b/Source/XRInteraction/Source/Runtime/Properties/UsableProperty.cs
@@ -3,6 +3,7 @@ using UnityEngine.Events;
 using UnityEngine.XR.Interaction.Toolkit;
 using VRBuilder.BasicInteraction.Properties;
 using VRBuilder.Core.Properties;
+using VRBuilder.Core.SceneObjects;
 using VRBuilder.Core.Settings;
 using VRBuilder.XRInteraction.Interactables;
 
@@ -58,6 +59,11 @@ namespace VRBuilder.XRInteraction.Properties
             Interactable.activated.AddListener(HandleXRUsageStarted);
             Interactable.deactivated.AddListener(HandleXRUsageStopped);
 
+            if (InheritSceneObjectLockState)
+            {
+                IsLocked = GetComponentInParent<ILockable>()?.IsLocked ?? IsLocked;
+            }
+            
             InternalSetLocked(IsLocked);
         }
 


### PR DESCRIPTION
I added a local based fix to check the 'InheritSceneObjectLockState' for the UseableProperty on component enable.