### PR TITLE
Add support for older version of VR Builder with Lock on parent object lock

### DIFF
--- a/Source/Core/Runtime/Properties/LockableProperty.cs
+++ b/Source/Core/Runtime/Properties/LockableProperty.cs
@@ -48,7 +48,7 @@ namespace VRBuilder.Core.Properties
         /// </summary>
         /// <remarks>This field is deprecated and will be removed in a future version of VR Builder. Use <see cref="InheritSceneObjectLockState"/> instead.</remarks>
         [HideInInspector]
-        [Obsolete("This field is deprecated and will be removed in a future version of VR Builder.", false)]
+        [Obsolete("This field is deprecated and will be removed in a future version of VR Builder. Please use InheritSceneObjectLockState instead.", false)]
         public bool LockOnParentObjectLock
         {
             get => InheritSceneObjectLockState;

--- a/Source/Core/Runtime/Properties/LockableProperty.cs
+++ b/Source/Core/Runtime/Properties/LockableProperty.cs
@@ -26,7 +26,7 @@ namespace VRBuilder.Core.Properties
         [FormerlySerializedAs("lockOnParentObjectLock")] 
         [SerializeField]
         [Tooltip("If this flag is checked, the object will inherit the lock state of its parent scene object.")]
-        private bool inheritSceneObjectLockState = true;
+        private bool inheritSceneObjectLockState;
         
         [SerializeField]
         [Tooltip("If this flag is checked, the object will never be locked by the VRBuilder process even if the parent scene object is locked.")]
@@ -41,6 +41,22 @@ namespace VRBuilder.Core.Properties
         {
             get => inheritSceneObjectLockState;
             set => inheritSceneObjectLockState = value;
+        }
+
+        /// <summary>
+        /// Decides if the property will be locked when the parent scene object is locked.
+        /// </summary>
+        /// <remarks>This field is deprecated and will be removed in a future version of VR Builder. Use <see cref="InheritSceneObjectLockState"/> instead.</remarks>
+        [HideInInspector]
+        [Obsolete("This field is deprecated and will be removed in a future version of VR Builder.", false)]
+        public bool LockOnParentObjectLock
+        {
+            get => InheritSceneObjectLockState;
+            set 
+            {
+                Debug.LogWarning("LockOnParentObjectLock is deprecated. Please use InheritSceneObjectLockState instead.");
+                InheritSceneObjectLockState = value;
+            }
         }
         
         /// <summary>
@@ -66,6 +82,7 @@ namespace VRBuilder.Core.Properties
 
             SceneObject.Locked += HandleObjectLocked;
             SceneObject.Unlocked += HandleObjectUnlocked;
+            LockOnParentObjectLock = true;
         }
 
         protected virtual void OnDisable()

--- a/Source/Core/Runtime/Properties/LockableProperty.cs
+++ b/Source/Core/Runtime/Properties/LockableProperty.cs
@@ -26,7 +26,7 @@ namespace VRBuilder.Core.Properties
         [FormerlySerializedAs("lockOnParentObjectLock")] 
         [SerializeField]
         [Tooltip("If this flag is checked, the object will inherit the lock state of its parent scene object.")]
-        private bool inheritSceneObjectLockState;
+        private bool inheritSceneObjectLockState = true;
         
         [SerializeField]
         [Tooltip("If this flag is checked, the object will never be locked by the VRBuilder process even if the parent scene object is locked.")]


### PR DESCRIPTION
Re-added the older field to support older addons and the UI addon made by LeFx GmbH but added a deprecated warning.