### PR TITLE
Removed default value on "LockOnParentObjectLock"

### DIFF
--- a/Source/Core/Runtime/Properties/LockableProperty.cs
+++ b/Source/Core/Runtime/Properties/LockableProperty.cs
@@ -82,7 +82,6 @@ namespace VRBuilder.Core.Properties
 
             SceneObject.Locked += HandleObjectLocked;
             SceneObject.Unlocked += HandleObjectUnlocked;
-            LockOnParentObjectLock = true;
         }
 
         protected virtual void OnDisable()


### PR DESCRIPTION
I noticed the warnings and removed the default set of the field in the "onEnable" event.

@mrwellmann I checked the UI addon but maybe you also can take a look.