### PR TITLE
Fixed set loc table being overwritten by currently open process

### DIFF
--- a/Source/Core/Editor/Configuration/RuntimeConfiguratorEditor.cs
+++ b/Source/Core/Editor/Configuration/RuntimeConfiguratorEditor.cs
@@ -187,19 +187,9 @@ namespace VRBuilder.Core.Editor.Configuration
 
         private void SaveLocalizationTableInProcess(string localizationTable)
         {
-            IProcess process = ProcessAssetManager.Load(GetProcessNameFromPath(configurator.GetSelectedProcess()));
+            IProcess process = GlobalEditorHandler.GetCurrentProcess();
             process.ProcessMetadata.StringLocalizationTable = localizationTable;
             ProcessAssetManager.Save(process);
-        }
-
-        private static string GetProcessNameFromPath(string path)
-        {
-            int slashIndex = path.LastIndexOf('/');
-            string fileName = path.Substring(slashIndex + 1);
-            int pointIndex = fileName.LastIndexOf('.');
-            fileName = fileName.Substring(0, pointIndex);
-
-            return fileName;
         }
 
         private void DrawProcessSelectionDropDown()


### PR DESCRIPTION
Changed how the process is saved after selecting a loc table in the Runtime Configurator.

The previous behavior was that a new process instance was loaded from disk then saved. This resulted in it being overwritten by the currently open process, once that was saved.

The loc table is now added to the currently open process. This should prevent overwriting it with a null value.