### PR TITLE
Added try/catch block to Load function of SettingsObject

### DIFF
--- a/Source/Core/Runtime/Settings/SettingsObject.cs
+++ b/Source/Core/Runtime/Settings/SettingsObject.cs
@@ -39,25 +39,35 @@ namespace VRBuilder.Core.Settings
 
         private static T Load()
         {
-            T settings = Resources.Load<T>(typeof(T).Name);
-
-            if (settings == null)
+            try
             {
-                // Create an instance
-                settings = CreateInstance<T>();
-#if UNITY_EDITOR
-                if (!Directory.Exists("Assets/MindPort/VR Builder/Resources"))
-                {
-                    Directory.CreateDirectory("Assets/MindPort/VR Builder/Resources");
-                }
-                AssetDatabase.CreateAsset(settings, $"Assets/MindPort/VR Builder/Resources/{typeof(T).Name}.asset");
-                AssetDatabase.SaveAssets();
-                AssetDatabase.Refresh();
-#endif
-            }
-            return settings;
-        }
+                T settings = Resources.Load<T>(typeof(T).Name);
 
+                if (settings == null)
+                {
+                    // Create an instance
+                    settings = CreateInstance<T>();
+#if UNITY_EDITOR
+                    if (!Directory.Exists("Assets/MindPort/VR Builder/Resources"))
+                    {
+                        Directory.CreateDirectory("Assets/MindPort/VR Builder/Resources");
+                    }
+
+                    AssetDatabase.CreateAsset(settings, $"Assets/MindPort/VR Builder/Resources/{typeof(T).Name}.asset");
+                    AssetDatabase.SaveAssets();
+                    AssetDatabase.Refresh();
+#endif
+                }
+
+                return settings;
+            }
+            catch (UnityException e)
+            {
+                Debug.LogException(e);
+                throw;
+            }
+        }
+        
         /// <summary>
         /// Saves the VR Builder settings, only works in editor.
         /// </summary>


### PR DESCRIPTION
The Load function silently fails when called from a non-main thread.
Added a try/catch block which logs the relevant exception, so that this is visible to the user.