### PR TITLE
Quick performance wins in step inspector

### DIFF
--- a/Source/Core/Editor/GraphViewEditingStrategy.cs
+++ b/Source/Core/Editor/GraphViewEditingStrategy.cs
@@ -47,6 +47,14 @@ namespace VRBuilder.Core.Editor
         /// <inheritdoc/>
         public void HandleCurrentProcessModified()
         {
+            if (stepWindow == null)
+            {
+                return;
+            }
+
+            // Keep Step Inspector synchronized with graph-side data mutations (e.g., transition edits)
+            // while preserving repaint throttling inside StepWindow.
+            stepWindow.MarkDirty();
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Editor/UI/Drawers/AbstractDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/AbstractDrawer.cs
@@ -29,8 +29,8 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
         public virtual GUIContent GetLabel(MemberInfo memberInfo, object memberOwner)
         {
-            Type memberType = ReflectionUtils.GetDeclaredTypeOfPropertyOrField(memberInfo);
-            object value = ReflectionUtils.GetValueFromPropertyOrField(memberOwner, memberInfo);
+            Type memberType = MemberAccessCache.GetDeclaredType(memberInfo);
+            object value = MemberAccessCache.GetValue(memberOwner, memberInfo);
 
             if (value != null)
             {

--- a/Source/Core/Editor/UI/Drawers/BehaviorInstantiatiorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/BehaviorInstantiatiorDrawer.cs
@@ -38,7 +38,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
             EditorGUI.EndDisabledGroup();
 
-            EditorGUI.BeginDisabledGroup(SystemClipboard.IsEntityInClipboard() == false || SystemClipboard.PasteEntity() is IBehavior == false);
+            EditorGUI.BeginDisabledGroup(SystemClipboard.IsEntityInClipboard<IBehavior>() == false);
 
             if (EditorDrawingHelper.DrawPasteButton(ref rect))
             {

--- a/Source/Core/Editor/UI/Drawers/ConditionInstantiatorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/ConditionInstantiatorDrawer.cs
@@ -31,7 +31,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
             EditorGUI.EndDisabledGroup();
 
-            EditorGUI.BeginDisabledGroup(SystemClipboard.IsEntityInClipboard() == false || SystemClipboard.PasteEntity() is ICondition == false);
+            EditorGUI.BeginDisabledGroup(SystemClipboard.IsEntityInClipboard<ICondition>() == false);
 
             if (EditorDrawingHelper.DrawPasteButton(ref rect))
             {

--- a/Source/Core/Editor/UI/Drawers/DataOwnerDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/DataOwnerDrawer.cs
@@ -3,7 +3,7 @@
 // Modifications copyright (c) 2021-2025 MindPort GmbH
 
 using System;
-using System.Linq;
+using System.Reflection;
 using VRBuilder.Core;
 using UnityEngine;
 
@@ -21,7 +21,13 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
             IData data = ((IDataOwner)currentValue).Data;
 
-            IProcessDrawer dataDrawer = DrawerLocator.GetDrawerForMember(EditorReflectionUtils.GetFieldsAndPropertiesToDraw(currentValue).First(member => member.Name == "Data"), currentValue);
+            MemberInfo dataMember = MemberAccessCache.GetDataMember(currentValue);
+            if (dataMember == null)
+            {
+                throw new MissingFieldException($"No drawable Data member found on {currentValue.GetType().FullName}.");
+            }
+
+            IProcessDrawer dataDrawer = DrawerLocator.GetDrawerForMember(dataMember, currentValue);
 
             return dataDrawer.Draw(rect, data, (value) => changeValueCallback(currentValue), label);
         }
@@ -30,7 +36,13 @@ namespace VRBuilder.Core.Editor.UI.Drawers
         {
             IData data = ((IDataOwner)value).Data;
 
-            IProcessDrawer dataDrawer = DrawerLocator.GetDrawerForMember(EditorReflectionUtils.GetFieldsAndPropertiesToDraw(value).First(member => member.Name == "Data"), value);
+            MemberInfo dataMember = MemberAccessCache.GetDataMember(value);
+            if (dataMember == null)
+            {
+                throw new MissingFieldException($"No drawable Data member found on {value.GetType().FullName}.");
+            }
+
+            IProcessDrawer dataDrawer = DrawerLocator.GetDrawerForMember(dataMember, value);
             return dataDrawer.GetLabel(data, declaredType);
         }
     }

--- a/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
+++ b/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
@@ -163,7 +163,10 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
         private static Action<object, object> CreatePropertySetter(PropertyInfo propertyInfo)
         {
-            if (propertyInfo.GetSetMethod(true) == null || propertyInfo.GetIndexParameters().Length > 0)
+            if (propertyInfo.GetSetMethod(true) == null
+                || propertyInfo.GetIndexParameters().Length > 0
+                || propertyInfo.DeclaringType == null
+                || propertyInfo.DeclaringType.IsValueType)
             {
                 return (owner, value) => propertyInfo.SetValue(owner, value, null);
             }
@@ -203,6 +206,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
         private static Action<object, object> CreateFieldSetter(FieldInfo fieldInfo)
         {
+            if (fieldInfo.DeclaringType == null || fieldInfo.DeclaringType.IsValueType)
+            {
+                return (owner, value) => fieldInfo.SetValue(owner, value);
+            }
+
             try
             {
                 ParameterExpression ownerParam = Expression.Parameter(typeof(object), "owner");

--- a/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
+++ b/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
@@ -1,0 +1,222 @@
+// Copyright (c) 2013-2019 Innoactive GmbH
+// Licensed under the Apache License, Version 2.0
+// Modifications copyright (c) 2021-2025 MindPort GmbH
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using VRBuilder.Core;
+using VRBuilder.Core.Editor;
+
+namespace VRBuilder.Core.Editor.UI.Drawers
+{
+    /// <summary>
+    /// Caches member accessors for hot editor draw paths to reduce repeated reflection overhead.
+    /// </summary>
+    internal static class MemberAccessCache
+    {
+        private sealed class Accessor
+        {
+            public Func<object, object> Getter { get; set; }
+            public Action<object, object> Setter { get; set; }
+            public Type DeclaredType { get; set; }
+        }
+
+        private sealed class MetadataMemberAccessor
+        {
+            public PropertyInfo Property { get; set; }
+            public FieldInfo Field { get; set; }
+        }
+
+        private static readonly Dictionary<MemberInfo, Accessor> accessorsByMember = new Dictionary<MemberInfo, Accessor>();
+        private static readonly Dictionary<Type, MetadataMemberAccessor> metadataMembersByType = new Dictionary<Type, MetadataMemberAccessor>();
+        private static readonly Dictionary<Type, MemberInfo> dataMemberByType = new Dictionary<Type, MemberInfo>();
+        private static readonly object locker = new object();
+
+        public static object GetValue(object owner, MemberInfo memberInfo)
+        {
+            return GetOrCreateAccessor(memberInfo).Getter(owner);
+        }
+
+        public static void SetValue(object owner, MemberInfo memberInfo, object value)
+        {
+            GetOrCreateAccessor(memberInfo).Setter(owner, value);
+        }
+
+        public static Type GetDeclaredType(MemberInfo memberInfo)
+        {
+            return GetOrCreateAccessor(memberInfo).DeclaredType;
+        }
+
+        public static bool TryGetMetadataMember(Type ownerType, out PropertyInfo property, out FieldInfo field)
+        {
+            MetadataMemberAccessor accessor;
+
+            lock (locker)
+            {
+                if (metadataMembersByType.TryGetValue(ownerType, out accessor) == false)
+                {
+                    accessor = new MetadataMemberAccessor
+                    {
+                        Property = ownerType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                            .FirstOrDefault(prop => typeof(Metadata).IsAssignableFrom(prop.PropertyType)),
+                        Field = ownerType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                            .FirstOrDefault(fld => typeof(Metadata).IsAssignableFrom(fld.FieldType))
+                    };
+
+                    metadataMembersByType[ownerType] = accessor;
+                }
+            }
+
+            property = accessor.Property;
+            field = accessor.Field;
+            return property != null || field != null;
+        }
+
+        public static MemberInfo GetDataMember(object owner)
+        {
+            if (owner == null)
+            {
+                return null;
+            }
+
+            Type type = owner.GetType();
+            lock (locker)
+            {
+                if (dataMemberByType.TryGetValue(type, out MemberInfo cachedMember))
+                {
+                    return cachedMember;
+                }
+            }
+
+            MemberInfo dataMember = EditorReflectionUtils.GetFieldsAndPropertiesToDraw(owner).FirstOrDefault(member => member.Name == "Data");
+            lock (locker)
+            {
+                dataMemberByType[type] = dataMember;
+            }
+
+            return dataMember;
+        }
+
+        private static Accessor GetOrCreateAccessor(MemberInfo memberInfo)
+        {
+            lock (locker)
+            {
+                if (accessorsByMember.TryGetValue(memberInfo, out Accessor accessor))
+                {
+                    return accessor;
+                }
+
+                accessor = CreateAccessor(memberInfo);
+                accessorsByMember[memberInfo] = accessor;
+                return accessor;
+            }
+        }
+
+        private static Accessor CreateAccessor(MemberInfo memberInfo)
+        {
+            if (memberInfo is PropertyInfo propertyInfo)
+            {
+                return new Accessor
+                {
+                    DeclaredType = propertyInfo.PropertyType,
+                    Getter = CreatePropertyGetter(propertyInfo),
+                    Setter = CreatePropertySetter(propertyInfo)
+                };
+            }
+
+            if (memberInfo is FieldInfo fieldInfo)
+            {
+                return new Accessor
+                {
+                    DeclaredType = fieldInfo.FieldType,
+                    Getter = CreateFieldGetter(fieldInfo),
+                    Setter = CreateFieldSetter(fieldInfo)
+                };
+            }
+
+            throw new ArgumentException("Unsupported MemberInfo type.", nameof(memberInfo));
+        }
+
+        private static Func<object, object> CreatePropertyGetter(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.GetGetMethod(true) == null || propertyInfo.GetIndexParameters().Length > 0)
+            {
+                return owner => propertyInfo.GetValue(owner, null);
+            }
+
+            try
+            {
+                ParameterExpression ownerParam = Expression.Parameter(typeof(object), "owner");
+                Expression typedOwner = Expression.Convert(ownerParam, propertyInfo.DeclaringType);
+                Expression propertyAccess = Expression.Property(typedOwner, propertyInfo);
+                UnaryExpression boxedResult = Expression.Convert(propertyAccess, typeof(object));
+                return Expression.Lambda<Func<object, object>>(boxedResult, ownerParam).Compile();
+            }
+            catch
+            {
+                return owner => propertyInfo.GetValue(owner, null);
+            }
+        }
+
+        private static Action<object, object> CreatePropertySetter(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.GetSetMethod(true) == null || propertyInfo.GetIndexParameters().Length > 0)
+            {
+                return (owner, value) => propertyInfo.SetValue(owner, value, null);
+            }
+
+            try
+            {
+                ParameterExpression ownerParam = Expression.Parameter(typeof(object), "owner");
+                ParameterExpression valueParam = Expression.Parameter(typeof(object), "value");
+
+                Expression typedOwner = Expression.Convert(ownerParam, propertyInfo.DeclaringType);
+                Expression typedValue = Expression.Convert(valueParam, propertyInfo.PropertyType);
+                BinaryExpression assign = Expression.Assign(Expression.Property(typedOwner, propertyInfo), typedValue);
+
+                return Expression.Lambda<Action<object, object>>(assign, ownerParam, valueParam).Compile();
+            }
+            catch
+            {
+                return (owner, value) => propertyInfo.SetValue(owner, value, null);
+            }
+        }
+
+        private static Func<object, object> CreateFieldGetter(FieldInfo fieldInfo)
+        {
+            try
+            {
+                ParameterExpression ownerParam = Expression.Parameter(typeof(object), "owner");
+                Expression typedOwner = Expression.Convert(ownerParam, fieldInfo.DeclaringType);
+                MemberExpression fieldAccess = Expression.Field(typedOwner, fieldInfo);
+                UnaryExpression boxedResult = Expression.Convert(fieldAccess, typeof(object));
+                return Expression.Lambda<Func<object, object>>(boxedResult, ownerParam).Compile();
+            }
+            catch
+            {
+                return owner => fieldInfo.GetValue(owner);
+            }
+        }
+
+        private static Action<object, object> CreateFieldSetter(FieldInfo fieldInfo)
+        {
+            try
+            {
+                ParameterExpression ownerParam = Expression.Parameter(typeof(object), "owner");
+                ParameterExpression valueParam = Expression.Parameter(typeof(object), "value");
+                Expression typedOwner = Expression.Convert(ownerParam, fieldInfo.DeclaringType);
+                Expression typedValue = Expression.Convert(valueParam, fieldInfo.FieldType);
+                BinaryExpression assign = Expression.Assign(Expression.Field(typedOwner, fieldInfo), typedValue);
+
+                return Expression.Lambda<Action<object, object>>(assign, ownerParam, valueParam).Compile();
+            }
+            catch
+            {
+                return (owner, value) => fieldInfo.SetValue(owner, value);
+            }
+        }
+    }
+}

--- a/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
+++ b/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs
@@ -1,20 +1,22 @@
-// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
-// Modifications copyright (c) 2021-2025 MindPort GmbH
+// Modifications copyright (c) 2021-2026 MindPort GmbH
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using VRBuilder.Core;
-using VRBuilder.Core.Editor;
 
 namespace VRBuilder.Core.Editor.UI.Drawers
 {
     /// <summary>
-    /// Caches member accessors for hot editor draw paths to reduce repeated reflection overhead.
+    /// Provides cached reflection-based access for fields and properties used by editor UI drawers.
     /// </summary>
+    /// <remarks>
+    /// Reading members through reflection every frame is expensive. This class builds getter/setter delegates once and reuses them.
+    /// It also caches type-level lookups, such as metadata members and the member named <c>Data</c>.
+    /// A shared lock protects cache access so callers can safely use this from different threads.
+    /// </remarks>
     internal static class MemberAccessCache
     {
         private sealed class Accessor
@@ -35,21 +37,45 @@ namespace VRBuilder.Core.Editor.UI.Drawers
         private static readonly Dictionary<Type, MemberInfo> dataMemberByType = new Dictionary<Type, MemberInfo>();
         private static readonly object locker = new object();
 
+        /// <summary>
+        /// Reads a field/property value from an object using a cached getter.
+        /// </summary>
+        /// <param name="owner">Object instance that contains the member.</param>
+        /// <param name="memberInfo">Field or property to read.</param>
+        /// <returns>Current value stored in the member.</returns>
         public static object GetValue(object owner, MemberInfo memberInfo)
         {
             return GetOrCreateAccessor(memberInfo).Getter(owner);
         }
 
+        /// <summary>
+        /// Writes a value to a field/property on an object using a cached setter.
+        /// </summary>
+        /// <param name="owner">Object instance that contains the member.</param>
+        /// <param name="memberInfo">Field or property to write.</param>
+        /// <param name="value">Value to assign to the member.</param>
         public static void SetValue(object owner, MemberInfo memberInfo, object value)
         {
             GetOrCreateAccessor(memberInfo).Setter(owner, value);
         }
 
+        /// <summary>
+        /// Gets the compile-time type declared by a field/property.
+        /// </summary>
+        /// <param name="memberInfo">Field or property to inspect.</param>
+        /// <returns>Type declared on the member definition.</returns>
         public static Type GetDeclaredType(MemberInfo memberInfo)
         {
             return GetOrCreateAccessor(memberInfo).DeclaredType;
         }
 
+        /// <summary>
+        /// Finds members on a type that hold <see cref="Metadata"/> and caches the result.
+        /// </summary>
+        /// <param name="ownerType">Type to search.</param>
+        /// <param name="property">Matching metadata property, if one exists.</param>
+        /// <param name="field">Matching metadata field, if one exists.</param>
+        /// <returns><c>true</c> if either output contains a member; otherwise <c>false</c>.</returns>
         public static bool TryGetMetadataMember(Type ownerType, out PropertyInfo property, out FieldInfo field)
         {
             MetadataMemberAccessor accessor;
@@ -75,6 +101,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             return property != null || field != null;
         }
 
+        /// <summary>
+        /// Finds the member named <c>Data</c> on the owner's type and caches that lookup per type.
+        /// </summary>
+        /// <param name="owner">Object whose type should be inspected.</param>
+        /// <returns>The <c>Data</c> member, or <c>null</c> when it does not exist.</returns>
         public static MemberInfo GetDataMember(object owner)
         {
             if (owner == null)
@@ -100,6 +131,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             return dataMember;
         }
 
+        /// <summary>
+        /// Returns a cached accessor pair (getter/setter) for a member, creating it the first time.
+        /// </summary>
+        /// <param name="memberInfo">Field or property to access.</param>
+        /// <returns>Cached accessor information for the requested member.</returns>
         private static Accessor GetOrCreateAccessor(MemberInfo memberInfo)
         {
             lock (locker)
@@ -115,6 +151,12 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
         }
 
+        /// <summary>
+        /// Builds getter/setter delegates and declared type info for a field/property.
+        /// </summary>
+        /// <param name="memberInfo">Field or property to wrap.</param>
+        /// <returns>Accessor object containing read/write delegates and declared type.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memberInfo"/> is not a field or property.</exception>
         private static Accessor CreateAccessor(MemberInfo memberInfo)
         {
             if (memberInfo is PropertyInfo propertyInfo)
@@ -140,6 +182,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             throw new ArgumentException("Unsupported MemberInfo type.", nameof(memberInfo));
         }
 
+        /// <summary>
+        /// Creates a fast getter delegate for a property.
+        /// </summary>
+        /// <param name="propertyInfo">Property to read from.</param>
+        /// <returns>Delegate that returns the property value for a given owner object.</returns>
         private static Func<object, object> CreatePropertyGetter(PropertyInfo propertyInfo)
         {
             if (propertyInfo.GetGetMethod(true) == null || propertyInfo.GetIndexParameters().Length > 0)
@@ -161,6 +208,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
         }
 
+        /// <summary>
+        /// Creates a fast setter delegate for a property.
+        /// </summary>
+        /// <param name="propertyInfo">Property to write to.</param>
+        /// <returns>Delegate that assigns a value to the property on a given owner object.</returns>
         private static Action<object, object> CreatePropertySetter(PropertyInfo propertyInfo)
         {
             if (propertyInfo.GetSetMethod(true) == null
@@ -188,6 +240,11 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
         }
 
+        /// <summary>
+        /// Creates a fast getter delegate for a field.
+        /// </summary>
+        /// <param name="fieldInfo">Field to read from.</param>
+        /// <returns>Delegate that returns the field value for a given owner object.</returns>
         private static Func<object, object> CreateFieldGetter(FieldInfo fieldInfo)
         {
             try
@@ -200,15 +257,20 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
             catch
             {
-                return owner => fieldInfo.GetValue(owner);
+                return fieldInfo.GetValue;
             }
         }
 
+        /// <summary>
+        /// Creates a fast setter delegate for a field.
+        /// </summary>
+        /// <param name="fieldInfo">Field to write to.</param>
+        /// <returns>Delegate that assigns a value to the field on a given owner object.</returns>
         private static Action<object, object> CreateFieldSetter(FieldInfo fieldInfo)
         {
             if (fieldInfo.DeclaringType == null || fieldInfo.DeclaringType.IsValueType)
             {
-                return (owner, value) => fieldInfo.SetValue(owner, value);
+                return fieldInfo.SetValue;
             }
 
             try
@@ -223,7 +285,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
             catch
             {
-                return (owner, value) => fieldInfo.SetValue(owner, value);
+                return fieldInfo.SetValue;
             }
         }
     }

--- a/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs.meta
+++ b/Source/Core/Editor/UI/Drawers/MemberAccessCache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4e93a80b27094d54a57446e6bb053860
+timeCreated: 1760000000

--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -772,13 +772,10 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
         private bool CanPaste(MetadataWrapper wrapper)
         {
-            if (SystemClipboard.IsEntityInClipboard() == false)
+            if (SystemClipboard.TryPeekEntity(out IEntity pastedEntity) == false)
             {
                 return false;
             }
-
-
-            IEntity pastedEntity = SystemClipboard.PasteEntity();
             IEntity parentEntity = VRBuilder.Core.Utils.ProcessUtils.GetParentEntity((IEntity)wrapper.Value, GlobalEditorHandler.GetCurrentProcess());
 
             return (pastedEntity is ICondition && parentEntity is ITransition) || (pastedEntity is IBehavior && parentEntity is IBehaviorCollection);

--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -706,8 +706,15 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 parentWrapper.Metadata.Remove(removedMetadataName);
             };
 
-            rect.height = Draw(rect, wrappedWrapper, wrappedWrapperChanged, label).height;
-            RestoreRemovedMetadata();
+            try
+            {
+                rect.height = Draw(rect, wrappedWrapper, wrappedWrapperChanged, label).height;
+            }
+            finally
+            {
+                RestoreRemovedMetadata();
+            }
+
             return rect;
         }
 

--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
-// Modifications copyright (c) 2021-2025 MindPort GmbH
+// Modifications copyright (c) 2021-2026 MindPort GmbH
 
 using System;
 using System.Collections;

--- a/Source/Core/Editor/UI/GraphView/IStepView.cs
+++ b/Source/Core/Editor/UI/GraphView/IStepView.cs
@@ -11,6 +11,11 @@ namespace VRBuilder.Core.Editor.UI.GraphView
         void SetStep(IStep newStep);
 
         /// <summary>
+        /// Marks the view as dirty and requests a refresh.
+        /// </summary>
+        void MarkDirty();
+
+        /// <summary>
         /// Resets the step view.
         /// </summary>
         void ResetStepView();

--- a/Source/Core/Editor/UI/Windows/StepWindow.cs
+++ b/Source/Core/Editor/UI/Windows/StepWindow.cs
@@ -223,6 +223,9 @@ namespace VRBuilder.Core.Editor.UI.Windows
                     GlobalEditorHandler.CurrentStepModified(modifiedStep);
                 }
             }
+
+            // Validation report and related warning labels/tooltips may change after deferred updates.
+            MarkDirty();
         }
     }
 }

--- a/Source/Core/Editor/UI/Windows/StepWindow.cs
+++ b/Source/Core/Editor/UI/Windows/StepWindow.cs
@@ -78,6 +78,11 @@ namespace VRBuilder.Core.Editor.UI.Windows
 
         private void OnDisable()
         {
+            if (isStepModifiedUpdateScheduled || pendingModifiedSteps.Count > 0)
+            {
+                FlushStepModified();
+            }
+
             Undo.undoRedoPerformed -= MarkDirty;
             EditorApplication.projectChanged -= MarkDirty;
             EditorApplication.hierarchyChanged -= MarkDirty;

--- a/Source/Core/Editor/UI/Windows/StepWindow.cs
+++ b/Source/Core/Editor/UI/Windows/StepWindow.cs
@@ -186,7 +186,7 @@ namespace VRBuilder.Core.Editor.UI.Windows
         {
         }
 
-        private void MarkDirty()
+        public void MarkDirty()
         {
             isDirty = true;
         }

--- a/Source/Core/Editor/UI/Windows/StepWindow.cs
+++ b/Source/Core/Editor/UI/Windows/StepWindow.cs
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
-// Modifications copyright (c) 2021-2025 MindPort GmbH
+// Modifications copyright (c) 2021-2026 MindPort GmbH
 
 using System.Collections.Generic;
 using UnityEditor;
@@ -69,6 +69,7 @@ namespace VRBuilder.Core.Editor.UI.Windows
                 window.Focus();
             }
         }
+
         public static StepWindow GetInstance(bool focus = false)
         {
             return GetWindow<StepWindow>("Step Inspector", focus);

--- a/Source/Core/Runtime/Serialization/NewtonsoftJsonProcessSerializer.cs
+++ b/Source/Core/Runtime/Serialization/NewtonsoftJsonProcessSerializer.cs
@@ -21,17 +21,9 @@ namespace VRBuilder.Core.Serialization.NewtonsoftJson
     public class NewtonsoftJsonProcessSerializer : IProcessSerializer
     {
         protected virtual int Version { get; } = 1;
-        private static readonly Lazy<List<JsonConverter>> CachedJsonConverters =
-            new Lazy<List<JsonConverter>>(CreateJsonConverters);
-        private static readonly Lazy<JsonSerializerSettings> CachedProcessSerializerSettings =
-            new Lazy<JsonSerializerSettings>(() => CreateSettings(CachedJsonConverters.Value));
-        private static readonly Lazy<JsonSerializerSettings> CachedStepSerializerSettings =
-            new Lazy<JsonSerializerSettings>(() =>
-            {
-                List<JsonConverter> converters = new List<JsonConverter> { new IndividualStepTransitionConverter() };
-                converters.AddRange(CachedJsonConverters.Value);
-                return CreateSettings(converters);
-            });
+        private static readonly List<JsonConverter> CachedJsonConverters = CreateJsonConverters();
+        private static readonly JsonSerializerSettings CachedProcessSerializerSettings = CreateSettings(CachedJsonConverters);
+        private static readonly JsonSerializerSettings CachedStepSerializerSettings = CreateStepSerializerSettings();
 
         private static JsonSerializerSettings CreateSettings(IList<JsonConverter> converters)
         {
@@ -46,17 +38,24 @@ namespace VRBuilder.Core.Serialization.NewtonsoftJson
             };
         }
 
+        private static JsonSerializerSettings CreateStepSerializerSettings()
+        {
+            List<JsonConverter> converters = new List<JsonConverter> { new IndividualStepTransitionConverter() };
+            converters.AddRange(CachedJsonConverters);
+            return CreateSettings(converters);
+        }
+
         /// <summary>
         /// Returns the json serializer settings used by the process deserialization.
         /// </summary>
         public static JsonSerializerSettings ProcessSerializerSettings
         {
-            get { return CachedProcessSerializerSettings.Value; }
+            get { return CachedProcessSerializerSettings; }
         }
 
         private static JsonSerializerSettings StepSerializerSettings
         {
-            get { return CachedStepSerializerSettings.Value; }
+            get { return CachedStepSerializerSettings; }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Implements VRB-3703 Step Inspector performance improvements in two phases to reduce editor CPU/GC overhead on complex steps while preserving existing behavior.

## What changed

### Phase 1 (quick wins)
- Replaced unconditional `OnInspectorUpdate -> Repaint()` with dirty/throttled repaint in `StepWindow`.
- Reduced IMGUI allocation churn in metadata UI by caching styles/textures in `MetadataWrapperDrawer`.
- Removed per-draw list copy (`new object[] + CopyTo`) in `ListDrawer`.

### Phase 2 (hot-path optimization)
- Added `MemberAccessCache` with cached getter/setter delegates for member access in editor draw paths.
- Switched hot paths to cached accessors:
  - `AbstractDrawer`
  - `ObjectDrawer`
  - `MetadataWrapperDrawer`
  - `DataOwnerDrawer`
  - `DrawerLocator`
- Added `Type -> IProcessDrawer` resolution memoization in `DrawerLocator`.
- Reduced metadata recursion churn by removing per-recursion dictionary cloning in `MetadataWrapperDrawer`.
- Debounced `GlobalEditorHandler.CurrentStepModified(step)` in `StepWindow` to avoid excessive expensive updates during rapid edits.

## Expected impact
- Lower idle and interaction-time CPU usage in Step Inspector.
- Reduced GC allocations/spikes when drawing complex behavior/condition trees.
- Better responsiveness during frequent field edits.
- No additional overhead / need for additional new boilerplate https://github.com/MindPort-GmbH/VR-Builder/pull/340#issuecomment-3915311363.

## Testing
- Needs an actual test case where performance was bad. I did test with like 20 Conditions / Behaviors in one step and it feels better but I never hat really bad lagging process before the optimization.

## Possible Issues
- https://github.com/MindPort-GmbH/VR-Builder/pull/340#issuecomment-3915784027