### PR TITLE
Add profile based voice support

### DIFF
--- a/Source/Core/Editor/TextToSpeech/Providers/DummyTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/DummyTextToSpeechProvider.cs
@@ -19,9 +19,16 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
             return Task.FromResult(audioClip);
         }
 
+        /// <inheritdoc />
         public ITextToSpeechConfiguration LoadConfig()
         {
             return null;
+        }
+
+        /// <inheritdoc />
+        public bool SupportsMultiSpeaker()
+        {
+            return false;
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Editor/TextToSpeech/Providers/DummyTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/DummyTextToSpeechProvider.cs
@@ -12,7 +12,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
     public class DummyTextToSpeechProvider : ITextToSpeechProvider
     {
         /// <inheritdoc/>
-        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
+        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker)
         {
             AudioClip audioClip = AudioClip.Create(text, channels: 1, frequency: 48000, lengthSamples: 1, stream: false);
 
@@ -23,12 +23,6 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         public ITextToSpeechConfiguration LoadConfig()
         {
             return null;
-        }
-
-        /// <inheritdoc />
-        public bool SupportsMultiSpeaker()
-        {
-            return false;
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
@@ -77,6 +77,12 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         }
 
         /// <inheritdoc />
+        public bool SupportsMultiSpeaker()
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
         public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
         {
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN

--- a/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
@@ -76,6 +76,12 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         }
 
         /// <inheritdoc />
+        public bool SupportsMultiSpeaker()
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
         public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
         {
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN

--- a/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
@@ -76,13 +76,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         }
 
         /// <inheritdoc />
-        public bool SupportsMultiSpeaker()
-        {
-            return false;
-        }
-
-        /// <inheritdoc />
-        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
+        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker)
         {
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
 

--- a/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/MicrosoftSapiTextToSpeechProvider.cs
@@ -77,13 +77,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         }
 
         /// <inheritdoc />
-        public bool SupportsMultiSpeaker()
-        {
-            return false;
-        }
-
-        /// <inheritdoc />
-        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
+        public Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker)
         {
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
 

--- a/Source/Core/Editor/TextToSpeech/Providers/WebTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/WebTextToSpeechProvider.cs
@@ -65,6 +65,11 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
             return Configuration;
         }
 
+        public bool SupportsMultiSpeaker()
+        {
+            return false;
+        }
+
         #endregion
 
         #region Download handling

--- a/Source/Core/Editor/TextToSpeech/Providers/WebTextToSpeechProvider.cs
+++ b/Source/Core/Editor/TextToSpeech/Providers/WebTextToSpeechProvider.cs
@@ -52,7 +52,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         }
 
         /// <inheritdoc/>
-        public async Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
+        public async Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker)
         {
             TaskCompletionSource<AudioClip> taskCompletion = new TaskCompletionSource<AudioClip>();
             CoroutineDispatcher.Instance.StartCoroutine(DownloadAudio(text, locale, taskCompletion));
@@ -63,11 +63,6 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Providers
         public ITextToSpeechConfiguration LoadConfig()
         {
             return Configuration;
-        }
-
-        public bool SupportsMultiSpeaker()
-        {
-            return false;
         }
 
         #endregion

--- a/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
+++ b/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
@@ -32,13 +32,13 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         /// <summary>
         /// Generates TTS audio and creates a file.
         /// </summary>
-        public static async Task CacheAudioClip(string key, string text, Locale locale)
+        public static async Task CacheAudioClip(string key, string text, Locale locale, string speaker = "")
         {
             ITextToSpeechProvider provider = TextToSpeechProviderFactory.Instance.CreateProvider();
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
             string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale);
             string filePath = $"{RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName}/{filename}";
-            AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale);
+            AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
 
             CacheAudio(audioClip, filePath, new NAudioConverter());
         }
@@ -85,6 +85,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             {
                 string key = null;
                 string text = validClips[i].Text;
+                string speaker = validClips[i].Speaker;
                 if (string.IsNullOrEmpty(localizationTable) == false)
                 {
                     text = LanguageUtils.GetLocalizedString(validClips[i].Text, localizationTable, locale);
@@ -102,7 +103,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
 
                 try
                 {
-                    await CacheAudioClip(key, text, locale);
+                    await CacheAudioClip(key, text, locale, speaker);
                 }
                 catch (Exception e)
                 {

--- a/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
+++ b/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
@@ -36,7 +36,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         {
             ITextToSpeechProvider provider = TextToSpeechProviderFactory.Instance.CreateProvider();
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
-            string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale);
+            string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale, speaker);
             string filePath = $"{RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName}/{filename}";
             string basedDirectoryPath = Application.isEditor ? Application.streamingAssetsPath : Application.persistentDataPath;
             string absolutePath = Path.Combine(basedDirectoryPath, filePath);

--- a/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
+++ b/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
@@ -38,9 +38,18 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
             string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale);
             string filePath = $"{RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName}/{filename}";
-            AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
-
-            CacheAudio(audioClip, filePath, new NAudioConverter());
+            string basedDirectoryPath = Application.isEditor ? Application.streamingAssetsPath : Application.persistentDataPath;
+            string absolutePath = Path.Combine(basedDirectoryPath, filePath);
+            
+            if (!File.Exists(absolutePath))
+            {
+                AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
+                CacheAudio(audioClip, filePath, new NAudioConverter());
+            }
+            else
+            {
+                UnityEngine.Debug.LogWarning($"File {absolutePath} already exists. Skipping generation.");
+            }
         }
 
         /// <summary>

--- a/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
+++ b/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
@@ -41,14 +41,14 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             string basedDirectoryPath = Application.isEditor ? Application.streamingAssetsPath : Application.persistentDataPath;
             string absolutePath = Path.Combine(basedDirectoryPath, filePath);
 
-            if (!File.Exists(absolutePath))
+            if (TextToSpeechSettings.Instance.IgnoreExistingTextToSpeechFiles && File.Exists(absolutePath))
             {
-                AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
-                CacheAudio(audioClip, filePath, new NAudioConverter());
+                UnityEngine.Debug.Log($"File {filename} already exists. Skipping TTS file generation.");
             }
             else
             {
-                UnityEngine.Debug.LogWarning($"File {absolutePath} already exists. Skipping generation.");
+                AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
+                CacheAudio(audioClip, filePath, new NAudioConverter());
             }
         }
 
@@ -147,34 +147,6 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         }
 
         /// <summary>
-        /// Texts of a specific TTS Content is cached
-        /// </summary>
-        /// <param name="configuration">Text to speech configuration that is used for this caching</param>
-        /// <param name="content">Text for cache checking</param>
-        /// <returns>True if the text is already cached as a TTS file</returns>
-        public static bool IsCached(this ITextToSpeechConfiguration configuration, ITextToSpeechContent content)
-        {
-            var currentDirName = RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName;
-
-            if (currentDirName != lastStreamingAssetCacheDirectoryName)
-            {
-                lastStreamingAssetCacheDirectoryName = currentDirName;
-
-                assetPaths = AssetDatabase.FindAssets("t:AudioClip", new[] { "Assets/StreamingAssets/" + currentDirName });
-                if (assetPaths.Length == 0)
-                {
-                    return false;
-                }
-            }
-
-            string key = content.Text; //key can be refactored out, when we have MD5 of both original text and translated text.
-            //TODO: this will not detect translated text and multiple speakers for the same text... maybe we should hash the text everywhere before translating
-            string md5 = TextToSpeechUtils.GetMd5Hash(content.Text);
-
-            return assetPaths.Any(assetPath => assetPath.Contains(md5) || assetPath.Contains(key));
-        }
-
-        /// <summary>
         /// Generates text-to-speech audio for the selected process, locale and configuration
         /// </summary>
         /// <param name="processName">The selected process where the audio should be generated</param>
@@ -187,7 +159,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             {
                 IEnumerable<ITextToSpeechContent> tts = EditorReflectionUtils
                     .GetNestedPropertiesFromData<ITextToSpeechContent>(process.Data)
-                    .Where(content => !string.IsNullOrEmpty(content.Text) && !configuration.IsCached(content))
+                    .Where(content => !string.IsNullOrEmpty(content.Text))
                     .ToList(); //this to list is necessary because if multi iteration
                 if (tts.Any())
                 {

--- a/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
+++ b/Source/Core/Editor/TextToSpeech/Utils/TextToSpeechEditorUtils.cs
@@ -28,7 +28,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
     {
         private static string lastStreamingAssetCacheDirectoryName;
         private static string[] assetPaths;
-        
+
         /// <summary>
         /// Generates TTS audio and creates a file.
         /// </summary>
@@ -40,7 +40,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             string filePath = $"{RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName}/{filename}";
             string basedDirectoryPath = Application.isEditor ? Application.streamingAssetsPath : Application.persistentDataPath;
             string absolutePath = Path.Combine(basedDirectoryPath, filePath);
-            
+
             if (!File.Exists(absolutePath))
             {
                 AudioClip audioClip = await provider.ConvertTextToSpeech(key, text, locale, speaker);
@@ -105,7 +105,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
                     key = validClips[i].Text;
                 }
 
-                if (EditorUtility.DisplayCancelableProgressBar($"Generating audio with {settings.Provider} in locale {locale.Identifier.Code}", $"{i + 1}/{validClips.Length}: {text}", (float) i / validClips.Length))
+                if (EditorUtility.DisplayCancelableProgressBar($"Generating audio with {settings.Provider} in locale {locale.Identifier.Code}", $"{i + 1}/{validClips.Length}: {text}", (float)i / validClips.Length))
                 {
                     break;
                 }
@@ -134,14 +134,14 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             if (Provider.enabled && Provider.onlineState != OnlineState.Offline)
             {
                 string[] assetPaths = AssetDatabase.FindAssets("t:AudioClip", new[] { "Assets/StreamingAssets/" + RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName });
-				if (assetPaths.Length > 0)
-				{
-					AssetList assetList = assetPaths.Aggregate(new AssetList(), (list, asset) =>
-					{
-						list.Add(new Asset(asset));
-						return list;
-					});
-					Provider.Revert(assetList, RevertMode.Unchanged);
+                if (assetPaths.Length > 0)
+                {
+                    AssetList assetList = assetPaths.Aggregate(new AssetList(), (list, asset) =>
+                    {
+                        list.Add(new Asset(asset));
+                        return list;
+                    });
+                    Provider.Revert(assetList, RevertMode.Unchanged);
                 }
             }
         }
@@ -155,24 +155,25 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         public static bool IsCached(this ITextToSpeechConfiguration configuration, ITextToSpeechContent content)
         {
             var currentDirName = RuntimeConfigurator.Configuration.GetTextToSpeechSettings().StreamingAssetCacheDirectoryName;
-            
+
             if (currentDirName != lastStreamingAssetCacheDirectoryName)
             {
                 lastStreamingAssetCacheDirectoryName = currentDirName;
 
                 assetPaths = AssetDatabase.FindAssets("t:AudioClip", new[] { "Assets/StreamingAssets/" + currentDirName });
                 if (assetPaths.Length == 0)
-				{
-					return false;
+                {
+                    return false;
                 }
             }
 
             string key = content.Text; //key can be refactored out, when we have MD5 of both original text and translated text.
-            string md5 = TextToSpeechUtils.GetMd5Hash(content.Text); //TODO: this will not detect translated text... maybe we should hash the text everywhere before translating
+            //TODO: this will not detect translated text and multiple speakers for the same text... maybe we should hash the text everywhere before translating
+            string md5 = TextToSpeechUtils.GetMd5Hash(content.Text);
 
             return assetPaths.Any(assetPath => assetPath.Contains(md5) || assetPath.Contains(key));
         }
-        
+
         /// <summary>
         /// Generates text-to-speech audio for the selected process, locale and configuration
         /// </summary>
@@ -205,7 +206,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
 
             return false;
         }
-        
+
         /// <summary>
         /// Generates text-to-speech audio for the selected process in all availed languages
         /// </summary>
@@ -214,10 +215,10 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         {
             ITextToSpeechProvider provider = TextToSpeechProviderFactory.Instance.CreateProvider();
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
-            
+
             List<Locale> locales = BuildLocales().ToList();
             bool filesGenerated = false;
-            
+
             UnityEngine.Debug.Log($"Generating TTS audio for all availed locales for the process {processName}");
             foreach (Locale locale in locales)
             {
@@ -226,7 +227,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
                     filesGenerated = true;
                 }
             }
-            
+
             if (!filesGenerated)
             {
                 UnityEngine.Debug.Log($"Found no TTS content to generate for all availed locales.");
@@ -234,7 +235,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         }
 
         #region ALL PROCESSES
-        
+
         /// <summary>
         /// Generates text-to-speech audio files for all available processes for the specified <paramref name="locale"/>.
         /// </summary>
@@ -243,7 +244,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
         {
             ITextToSpeechProvider provider = TextToSpeechProviderFactory.Instance.CreateProvider();
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
-            
+
             IEnumerable<string> processNames = GetAllProcesses();
             bool filesGenerated = false;
 
@@ -262,7 +263,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
                 UnityEngine.Debug.Log($"Found no TTS content to generate for locale {locale}.");
             }
         }
-        
+
         /// <summary>
         /// Generates TTS audio files for all project locales for all processes.
         /// </summary>
@@ -275,7 +276,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
                 await GenerateTextToSpeechForAllProcesses(locale);
             }
         }
-        
+
         /// <summary>
         /// Generates text-to-speech audio files for the active or default locale for all processes.
         /// </summary>
@@ -284,7 +285,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             await GenerateTextToSpeechForAllProcesses(LanguageSettings.Instance.ActiveOrDefaultLocale);
             AssetDatabase.Refresh();
         }
-        
+
         #endregion
 
         #region ACTIVE SCENE PROCESSES
@@ -309,7 +310,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
                 await GenerateTextToSpeechActiveScene(locale);
             }
         }
-        
+
         /// <summary>
         /// Generates the text-to-speech audio for the current scene in the selected language
         /// </summary>
@@ -318,7 +319,7 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             ITextToSpeechProvider provider = TextToSpeechProviderFactory.Instance.CreateProvider();
             ITextToSpeechConfiguration configuration = provider.LoadConfig();
             var activeScene = SceneManager.GetActiveScene();
-            
+
             var runtimeConfigurator = activeScene.GetRootGameObjects().Select(o => o.GetComponentInChildren<RuntimeConfigurator>(true)).First(o => o != null);
             if (runtimeConfigurator != null)
             {
@@ -328,12 +329,12 @@ namespace VRBuilder.Core.Editor.TextToSpeech.Utils
             {
                 UnityEngine.Debug.LogWarning($"No active process config found. TTS files for current local {locale} in the active scene {activeScene.name} could not be generated.");
             }
-            
+
             AssetDatabase.Refresh();
         }
-        
+
         #endregion
-        
+
         /// <summary>
         /// Get an enumerable list of the locales for building processes
         /// </summary>

--- a/Source/Core/Editor/UI/Drawers/PlayAudioBehaviorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/PlayAudioBehaviorDrawer.cs
@@ -1,15 +1,11 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Source.Core.Runtime.TextToSpeech;
 using UnityEditor;
 using UnityEngine;
 using VRBuilder.Core.Behaviors;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.TextToSpeech;
-using VRBuilder.Core.TextToSpeech.Providers;
-using VRBuilder.Core.Utils;
-using VRBuilder.Core.Utils.Audio;
 
 namespace VRBuilder.Core.Editor.UI.Drawers
 {

--- a/Source/Core/Editor/UI/Drawers/PlayAudioBehaviorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/PlayAudioBehaviorDrawer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using VRBuilder.Core.Behaviors;
@@ -22,8 +21,6 @@ namespace VRBuilder.Core.Editor.UI.Drawers
         private bool previewAudio;
         private bool hasBeenPlayed;
         private float audioStartTime;
-        private Type currentProviderType;
-        private ITextToSpeechProvider currentProvider;
         
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
@@ -60,14 +57,8 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 height += nextPosition.height;
                 height += EditorDrawingHelper.VerticalSpacing;
                 nextPosition.y = rect.y + height;
-
-                currentProviderType ??= ReflectionUtils.GetConcreteImplementationsOf<ITextToSpeechProvider>().FirstOrDefault(type => type.Name == TextToSpeechSettings.Instance.Provider);
-                if (currentProvider == null && currentProviderType != null && Activator.CreateInstance(currentProviderType) is ITextToSpeechProvider provider)
-                {
-                    currentProvider = provider;
-                }
                 
-                if (currentProvider != null && currentProvider.SupportsMultiSpeaker())
+                if (TextToSpeechSettings.Instance.GetCurrentTextToSpeechProvider().SupportsMultiSpeaker())
                 {
                     MemberInfo speaker = data.GetType().GetMember(nameof(data.SelectedSpeaker)).First();
                     nextPosition = DrawerLocator.GetDrawerForMember(speaker, data)

--- a/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.IO;
+using Source.Core.Runtime.TextToSpeech;
+using VRBuilder.Core.TextToSpeech;
+using VRBuilder.Core.TextToSpeech.Providers;
+
+namespace VRBuilder.Core.Editor.UI.Drawers
+{
+    /// <summary>
+    /// Drawer for a dropdown listing all availed speakers of <see cref="ITextToSpeechProvider"/> if multiple speaker supported and allowing to select one by index.
+    /// </summary>
+    public class SpeakerDropdownDrawer : DropdownDrawer<string>
+    {
+        /// <inheritdoc/>
+        protected override IList<DropDownElement<string>> PossibleOptions => options;
+
+        private List<DropDownElement<string>> options = new();
+
+        public SpeakerDropdownDrawer()
+        {
+            BuildSceneList();
+
+            TextToSpeechSettings.Instance.ProviderChanged += BuildSceneList;
+        }
+
+        private void BuildSceneList()
+        {
+            options.Clear();
+
+            var textToSpeechProvider = TextToSpeechSettings.Instance.GetCurrentTextToSpeechProvider();
+
+            if (textToSpeechProvider is ITextToSpeechSpeaker speakers)
+            {
+                foreach (var speaker in speakers.GetSpeaker())
+                {
+                    options.Add(new DropDownElement<string>(speaker, speaker));
+                }
+            }
+        }
+    }
+}

--- a/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
@@ -1,45 +1,44 @@
 using System.Collections.Generic;
-using System.IO;
-using Source.Core.Runtime.TextToSpeech;
-using VRBuilder.Core.Configuration;
+using System.Linq;
+using UnityEngine;
 using VRBuilder.Core.TextToSpeech;
-using VRBuilder.Core.TextToSpeech.Providers;
 
 namespace VRBuilder.Core.Editor.UI.Drawers
 {
     /// <summary>
-    /// Drawer for a dropdown listing all availed speakers of <see cref="ITextToSpeechProvider"/> if multiple speaker supported and allowing to select one by index.
+    /// Drawer for a dropdown listing all configured voice profiles in <see cref="TextToSpeechSettings"/>.
     /// </summary>
     public class SpeakerDropdownDrawer : DropdownDrawer<string>
     {
+        private List<DropDownElement<string>> options = new();
+        private GUIContent[] labels;
+
         /// <inheritdoc/>
         protected override IList<DropDownElement<string>> PossibleOptions => options;
 
-        private List<DropDownElement<string>> options = new();
-
         public SpeakerDropdownDrawer()
         {
-            BuildSceneList();
+            BuildProfileList();
 
-            TextToSpeechSettings.Instance.ProviderChanged += BuildSceneList;
+            TextToSpeechSettings.Instance.ProviderChanged += BuildProfileList;
+            TextToSpeechSettings.Instance.VoiceProfilesChanged += BuildProfileList;
         }
 
-        private void BuildSceneList()
+        private void BuildProfileList()
         {
             options.Clear();
 
-            if (RuntimeConfigurator.Exists)
+            foreach (var profile in TextToSpeechSettings.Instance.VoiceProfiles)
             {
-                var textToSpeechProvider = TextToSpeechSettings.Instance.GetCurrentTextToSpeechProvider();
-
-                if (textToSpeechProvider is ITextToSpeechSpeaker speakers)
-                {
-                    foreach (var speaker in speakers.GetSpeaker())
-                    {
-                        options.Add(new DropDownElement<string>(speaker, speaker));
-                    }
-                }
+                options.Add(new DropDownElement<string>(profile.DisplayName, profile.DisplayName));
             }
+
+            if (options.Count == 0)
+            {
+                options.Add(new DropDownElement<string>("Default", "Default"));
+            }
+
+            labels = options.Select(item => item.Label).ToArray();
         }
     }
 }

--- a/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
@@ -20,8 +20,18 @@ namespace VRBuilder.Core.Editor.UI.Drawers
         {
             BuildProfileList();
 
+            // Remove existing subscription
+            TextToSpeechSettings.Instance.ProviderChanged -= BuildProfileList;
+            TextToSpeechSettings.Instance.VoiceProfilesChanged -= BuildProfileList;
+            
             TextToSpeechSettings.Instance.ProviderChanged += BuildProfileList;
             TextToSpeechSettings.Instance.VoiceProfilesChanged += BuildProfileList;
+        }
+        
+        ~SpeakerDropdownDrawer()
+        {
+            TextToSpeechSettings.Instance.ProviderChanged -= BuildProfileList;
+            TextToSpeechSettings.Instance.VoiceProfilesChanged -= BuildProfileList;
         }
 
         private void BuildProfileList()

--- a/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Source.Core.Runtime.TextToSpeech;
+using VRBuilder.Core.Configuration;
 using VRBuilder.Core.TextToSpeech;
 using VRBuilder.Core.TextToSpeech.Providers;
 
@@ -27,13 +28,16 @@ namespace VRBuilder.Core.Editor.UI.Drawers
         {
             options.Clear();
 
-            var textToSpeechProvider = TextToSpeechSettings.Instance.GetCurrentTextToSpeechProvider();
-
-            if (textToSpeechProvider is ITextToSpeechSpeaker speakers)
+            if (RuntimeConfigurator.Exists)
             {
-                foreach (var speaker in speakers.GetSpeaker())
+                var textToSpeechProvider = TextToSpeechSettings.Instance.GetCurrentTextToSpeechProvider();
+
+                if (textToSpeechProvider is ITextToSpeechSpeaker speakers)
                 {
-                    options.Add(new DropDownElement<string>(speaker, speaker));
+                    foreach (var speaker in speakers.GetSpeaker())
+                    {
+                        options.Add(new DropDownElement<string>(speaker, speaker));
+                    }
                 }
             }
         }

--- a/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs.meta
+++ b/Source/Core/Editor/UI/Drawers/SpeakerDropdownDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: de0cb89a7f4a43fb8bb8be8e0bb8ab85
+timeCreated: 1767803130

--- a/Source/Core/Editor/UI/Menu/CommunityMenuEntry.cs
+++ b/Source/Core/Editor/UI/Menu/CommunityMenuEntry.cs
@@ -12,7 +12,7 @@ namespace VRBuilder.Core.Editor.Menu
         /// <summary>
         /// Allows to open the URL to the MindPort community.
         /// </summary>
-        [MenuItem("Tools/VR Builder/Join VR-Builder Community", false, 200)]
+        [MenuItem("Tools/VR Builder/Join VR Builder Community", false, 200)]
         private static void OpenCommunityPage()
         {
             Application.OpenURL("https://discord.com/invite/aUdwRRPgrK?utm_source=unity_editor&utm_medium=referral&utm_campaign=from_unity&utm_id=from_unity");

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -140,7 +140,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             EditorGUILayout.LabelField("Voice Profiles", CustomHeader);
             GUILayout.Space(8);
             
-            EditorGUILayout.HelpBox("Voice profiles map languages to specific voices for each TTS provider. Create profiles to define which voice should be used for each language.", MessageType.Info);
+            EditorGUILayout.HelpBox("Voice profiles map languages to specific voices for each Text-To-Speech provider. Create profiles to define which voice should be used for each language.\nIf the Text-To-Speech provider supports multiple voices", MessageType.Info);
             
             GUILayout.Space(4);
             

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -91,7 +91,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             }
             
             // Voice Profiles Section
-            DrawVoiceProfilesSection();
+            //DrawVoiceProfilesSection();
             
             // Text to speech provider settings
             DrawTextToSpeechProviderSelection();

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -86,11 +86,13 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             {
                 cacheDirectoryName = lastSelectedCacheDirectory;
                 textToSpeechSettings.StreamingAssetCacheDirectoryName = lastSelectedCacheDirectory;
+                textToSpeechSettings.Save();
             }
 
             if (generateAudioInBuildingProcess != textToSpeechSettings.GenerateAudioInBuildingProcess)
             {
                 textToSpeechSettings.GenerateAudioInBuildingProcess = generateAudioInBuildingProcess;
+                textToSpeechSettings.Save();
             }
             
             // Voice Profiles Section

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Source.Core.Runtime.TextToSpeech;
-using Source.Core.Runtime.TextToSpeech.Utils.VRBuilder.Core.TextToSpeech;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Localization.Settings;

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -63,11 +63,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
         {
             get
             {
-                if (customHeader == null)
-                {
-                    customHeader = new GUIStyle(BuilderEditorStyles.Header);
-                    customHeader.fixedHeight = 25f;
-                }
+                customHeader ??= new GUIStyle(BuilderEditorStyles.Header) { fixedHeight = 25f };
 
                 return customHeader;
             }
@@ -101,7 +97,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             
             // Voice Profiles Section
             // Draw only profile if they are supported by at least one text-to-speech provider that implements ITextToSpeechSpeaker
-            if (speakersCache.Any())
+            if (speakersCache.Count != 0)
             {
                 DrawVoiceProfilesSection();
             }

--- a/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/TextToSpeechSettingsEditor.cs
@@ -32,6 +32,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
         private ITextToSpeechProvider currentElement;
         private ITextToSpeechConfiguration currentElementSettings;
         private bool generateAudioInBuildingProcess;
+        private bool ignoreExistingTextToSpeechFiles;
 
         // Text to speech provider management
         private string lastSelectedCacheDirectory = "";
@@ -75,23 +76,38 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             EditorGUI.BeginChangeCheck();
 
             lastSelectedCacheDirectory = EditorGUILayout.TextField(new GUIContent("Cache Directory Name", "Name for the streaming asset cache directory for TTS files"), lastSelectedCacheDirectory);
-            generateAudioInBuildingProcess = EditorGUILayout.Toggle(new GUIContent("Generate TTS while Building", "If checked, text-to-speech audio will be generated during the building process, otherwise it won't generate TTS audio during the building process."), generateAudioInBuildingProcess);
+            generateAudioInBuildingProcess = EditorGUILayout.Toggle(new GUIContent("Create TTS while Building", "If checked, text-to-speech audio will be generated during the building process, otherwise it won't generate TTS audio during the building process."), generateAudioInBuildingProcess);
 
             if (!generateAudioInBuildingProcess)
             {
                 EditorGUILayout.HelpBox("Text-to-speech files will not be generated during the building process. Text-to-speech files must be generated manually.", MessageType.Warning);
             }
             
+            ignoreExistingTextToSpeechFiles = EditorGUILayout.Toggle(new GUIContent("Ignore Existing TTS files", "If checked, existing text-to-speech audio files are skipped during the generation process and are not regenerated, otherwise it will override all existing files while generating."), ignoreExistingTextToSpeechFiles);
+            if (ignoreExistingTextToSpeechFiles)
+            {
+                EditorGUILayout.HelpBox("Existing Text-to-speech files will be ignored during the generation process.", MessageType.Warning);
+            }
+            
             if (lastSelectedCacheDirectory != cacheDirectoryName)
             {
                 cacheDirectoryName = lastSelectedCacheDirectory;
                 textToSpeechSettings.StreamingAssetCacheDirectoryName = lastSelectedCacheDirectory;
-                textToSpeechSettings.Save();
             }
 
             if (generateAudioInBuildingProcess != textToSpeechSettings.GenerateAudioInBuildingProcess)
             {
                 textToSpeechSettings.GenerateAudioInBuildingProcess = generateAudioInBuildingProcess;
+            }
+
+            if (ignoreExistingTextToSpeechFiles != textToSpeechSettings.IgnoreExistingTextToSpeechFiles)
+            {
+                textToSpeechSettings.IgnoreExistingTextToSpeechFiles = ignoreExistingTextToSpeechFiles;
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorUtility.SetDirty(textToSpeechSettings);
                 textToSpeechSettings.Save();
             }
             
@@ -128,6 +144,7 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             
             textToSpeechSettings.Provider = providers[providersIndex];
             generateAudioInBuildingProcess = textToSpeechSettings.GenerateAudioInBuildingProcess;
+            ignoreExistingTextToSpeechFiles = textToSpeechSettings.IgnoreExistingTextToSpeechFiles;
 
             if (EditorPrefs.HasKey(PrefKeyScope))
             {

--- a/Source/Core/Runtime/Behaviors/PlayAudioBehavior.cs
+++ b/Source/Core/Runtime/Behaviors/PlayAudioBehavior.cs
@@ -45,6 +45,11 @@ namespace VRBuilder.Core.Behaviors
             /// The Unity's audio source to play the sound. If not set, it will use <seealso cref="RuntimeConfigurator.Configuration.InstructionPlayer"/>.
             /// </summary>
             public AudioSource AudioPlayer { get; set; }
+            
+            /// <summary>
+            /// If the selected text-to-speech provider supports multiple speakers, this option can be used to set.
+            /// </summary>
+            public string SelectedSpeaker { get; set; }
 
             /// <inheritdoc />
             public Metadata Metadata { get; set; }

--- a/Source/Core/Runtime/Behaviors/PlayAudioBehavior.cs
+++ b/Source/Core/Runtime/Behaviors/PlayAudioBehavior.cs
@@ -45,11 +45,6 @@ namespace VRBuilder.Core.Behaviors
             /// The Unity's audio source to play the sound. If not set, it will use <seealso cref="RuntimeConfigurator.Configuration.InstructionPlayer"/>.
             /// </summary>
             public AudioSource AudioPlayer { get; set; }
-            
-            /// <summary>
-            /// If the selected text-to-speech provider supports multiple speakers, this option can be used to set.
-            /// </summary>
-            public string SelectedSpeaker { get; set; }
 
             /// <inheritdoc />
             public Metadata Metadata { get; set; }

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechContent.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechContent.cs
@@ -13,7 +13,7 @@ namespace VRBuilder.Core.TextToSpeech
         string Text { get; }
         
         /// <summary>
-        /// The speaker to use for the TTS provider if supported.
+        /// The profile to use for the TTS provider if supported.
         /// </summary>
         string Speaker { get; }
     }

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechContent.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechContent.cs
@@ -11,5 +11,10 @@ namespace VRBuilder.Core.TextToSpeech
         /// Text content to be fed to the TTS provider.
         /// </summary>
         string Text { get; }
+        
+        /// <summary>
+        /// The speaker to use for the TTS provider if supported.
+        /// </summary>
+        string Speaker { get; }
     }
 }

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechProvider.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechProvider.cs
@@ -6,7 +6,7 @@ using VRBuilder.Core.TextToSpeech.Configuration;
 namespace VRBuilder.Core.TextToSpeech.Providers
 {
     /// <summary>
-    /// TextToSpeechProvider allows to convert text to AudioClips.
+    /// TextToSpeechProvider allows converting text to AudioClips.
     /// </summary>
     public interface ITextToSpeechProvider
     {
@@ -24,6 +24,16 @@ namespace VRBuilder.Core.TextToSpeech.Providers
         /// <returns>ready to play Audioclip</returns>
         Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale);
 
+        /// <summary>
+        /// Load config while editor- and runtime
+        /// </summary>
+        /// <returns>Returns configuration for the provider if successful</returns>
         public ITextToSpeechConfiguration LoadConfig();
+
+        /// <summary>
+        /// If the text-to-speech provider supports multiple speakers
+        /// </summary>
+        /// <returns>True if this feature is supported</returns>
+        public bool SupportsMultiSpeaker();
     }
 }

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechProvider.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechProvider.cs
@@ -21,19 +21,14 @@ namespace VRBuilder.Core.TextToSpeech.Providers
         /// <param name="key">unique identifier of the original text can be either LanguageTable key or md5hash of untranslated text</param>
         /// <param name="text">translated text</param>
         /// <param name="locale">locale of translated text</param>
+        /// <param name="speaker">used speaker, if the provider supports it</param>
         /// <returns>ready to play Audioclip</returns>
-        Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale);
+        Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker = "");
 
         /// <summary>
         /// Load config while editor- and runtime
         /// </summary>
         /// <returns>Returns configuration for the provider if successful</returns>
         public ITextToSpeechConfiguration LoadConfig();
-
-        /// <summary>
-        /// If the text-to-speech provider supports multiple speakers
-        /// </summary>
-        /// <returns>True if this feature is supported</returns>
-        public bool SupportsMultiSpeaker();
     }
 }

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using VRBuilder.Core.TextToSpeech.Configuration;
+
+namespace Source.Core.Runtime.TextToSpeech
+{
+    /// <summary>
+    /// ITextToSpeechSpeaker allows supporting different voices for Text-To-Speech
+    /// </summary>
+    public interface ITextToSpeechSpeaker
+    {
+        /// <summary>
+        /// Returns a list of all speakers that are set in the <see cref="ITextToSpeechConfiguration"/>
+        /// </summary>
+        /// <returns></returns>
+        public List<string> GetSpeaker();
+    }
+}

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using VRBuilder.Core.TextToSpeech.Configuration;
 
-namespace Source.Core.Runtime.TextToSpeech
+namespace VRBuilder.Core.TextToSpeech
 {
     /// <summary>
     /// ITextToSpeechSpeaker allows supporting different voices for Text-To-Speech

--- a/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs.meta
+++ b/Source/Core/Runtime/TextToSpeech/ITextToSpeechSpeaker.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 38b29e7eb9e84250b33ff2ab44d9e8ce
+timeCreated: 1767803812

--- a/Source/Core/Runtime/TextToSpeech/Providers/FileTextToSpeechProvider/FileTextToSpeechProvider.cs
+++ b/Source/Core/Runtime/TextToSpeech/Providers/FileTextToSpeechProvider/FileTextToSpeechProvider.cs
@@ -50,9 +50,16 @@ namespace VRBuilder.Core.TextToSpeech.Providers
             return audioClip;
         }
 
+        /// <inheritdoc />
         public ITextToSpeechConfiguration LoadConfig()
         {
             return configuration;
+        }
+
+        /// <inheritdoc/>
+        public bool SupportsMultiSpeaker()
+        {
+            return false;
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Runtime/TextToSpeech/Providers/FileTextToSpeechProvider/FileTextToSpeechProvider.cs
+++ b/Source/Core/Runtime/TextToSpeech/Providers/FileTextToSpeechProvider/FileTextToSpeechProvider.cs
@@ -21,7 +21,7 @@ namespace VRBuilder.Core.TextToSpeech.Providers
         protected ITextToSpeechConfiguration configuration = new FileTextToSpeechConfiguration();
 
         /// <inheritdoc/>
-        public async Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale)
+        public async Task<AudioClip> ConvertTextToSpeech(string key, string text, Locale locale, string speaker)
         {
             string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale);
             string filePath = GetPathToFile(filename);
@@ -39,7 +39,7 @@ namespace VRBuilder.Core.TextToSpeech.Providers
             else
             {
                 Debug.Log($"No audio cached for TTS string. File {filePath} not found. Audio will be generated in real time.");
-                audioClip = await TextToSpeechProviderFactory.Instance.CreateProvider().ConvertTextToSpeech(key, text, locale);
+                audioClip = await TextToSpeechProviderFactory.Instance.CreateProvider().ConvertTextToSpeech(key, text, locale, speaker);
             }
 
             if (audioClip is null)
@@ -54,12 +54,6 @@ namespace VRBuilder.Core.TextToSpeech.Providers
         public ITextToSpeechConfiguration LoadConfig()
         {
             return configuration;
-        }
-
-        /// <inheritdoc/>
-        public bool SupportsMultiSpeaker()
-        {
-            return false;
         }
 
         /// <inheritdoc/>

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
@@ -158,7 +158,7 @@ namespace VRBuilder.Core.TextToSpeech
 
         private void OnSelectedLocaleChanged(Locale locale)
         {
-            if (Application.isPlaying)
+            if (Application.isPlaying && !IsEmpty())
             {
                 InitializeAudioClip();
             }

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
@@ -17,7 +17,7 @@ namespace VRBuilder.Core.TextToSpeech
     /// This class retrieves and stores AudioClips generated based in a provided localized text. 
     /// </summary>
     [DataContract(IsReference = true)]
-    [Core.Attributes.DisplayName("Play Text to Speech")]
+    [Attributes.DisplayName("Play Text to Speech")]
     public class TextToSpeechAudio : TextToSpeechContent, IAudioData
     {
         private bool isReady;
@@ -29,7 +29,7 @@ namespace VRBuilder.Core.TextToSpeech
         /// <inheritdoc/>
         [DataMember]
         [UsesSpecificProcessDrawer("MultiLineStringDrawer")]
-        [Core.Attributes.DisplayName("Text/Key")]
+        [Attributes.DisplayName("Text/Key")]
         public override string Text
         {
             get => text;
@@ -39,7 +39,7 @@ namespace VRBuilder.Core.TextToSpeech
         /// <inheritdoc/>
         [DataMember]
         [UsesSpecificProcessDrawer("SpeakerDropdownDrawer")]
-        [Core.Attributes.DisplayName("Selected Speaker")]
+        [Attributes.DisplayName("Selected Profile")]
         public override string Speaker
         {
             get => speaker;

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechAudio.cs
@@ -23,6 +23,7 @@ namespace VRBuilder.Core.TextToSpeech
         private bool isReady;
         private bool isLoading;
         private string text;
+        private string speaker;
         private AudioClip audioClip;
 
         /// <inheritdoc/>
@@ -35,13 +36,24 @@ namespace VRBuilder.Core.TextToSpeech
             set => text = value;
         }
 
+        /// <inheritdoc/>
+        [DataMember]
+        [UsesSpecificProcessDrawer("SpeakerDropdownDrawer")]
+        [Core.Attributes.DisplayName("Selected Speaker")]
+        public override string Speaker
+        {
+            get => speaker;
+            set => speaker = value;
+        }
+        
         protected TextToSpeechAudio() : this("")
         {
         }
 
-        public TextToSpeechAudio(string text)
+        public TextToSpeechAudio(string text, string speaker = "")
         {
             this.text = text;
+            this.speaker = speaker;
 
             if (LocalizationSettings.HasSettings)
             {
@@ -124,7 +136,7 @@ namespace VRBuilder.Core.TextToSpeech
                 usedText = text;
             }
 
-            Task<AudioClip> t = provider.ConvertTextToSpeech(usedKey, usedText, LanguageSettings.Instance.ActiveOrDefaultLocale);
+            Task<AudioClip> t = provider.ConvertTextToSpeech(usedKey, usedText, LanguageSettings.Instance.ActiveOrDefaultLocale, Speaker);
             t.ContinueWith(task =>
             {
                 try

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechContent.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechContent.cs
@@ -12,6 +12,9 @@ namespace VRBuilder.Core.TextToSpeech
     {
         /// <inheritdoc/>
         public abstract string Text { get; set; }
+        
+        /// <inheritdoc/>
+        public abstract string Speaker { get; set; }
 
         /// <inheritdoc/>
         public abstract string GetLocalizedContent();

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -39,11 +39,13 @@ namespace VRBuilder.Core.TextToSpeech
         /// <summary>
         /// If true, the audio will not be generated at the building process
         /// </summary>
+        [SerializeField]
         public bool GenerateAudioInBuildingProcess = true;
         
         /// <summary>
         /// StreamingAsset directory name which is used to load/save audio files.
         /// </summary>
+        [SerializeField]
         public string StreamingAssetCacheDirectoryName = "TextToSpeech";
 
         /// <summary>

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -13,7 +13,20 @@ namespace VRBuilder.Core.TextToSpeech
         /// Name of the <see cref="ITextToSpeechProvider"/>.
         /// </summary>
         [HideInInspector]
-        public string Provider;
+        public string Provider
+        {
+            get => provider;
+            set
+            {
+                provider = value;
+                if (currentProvider?.GetType().Name != Provider)
+                {
+                    currentProviderType = null;
+                    currentProvider = null;
+                    ProviderChanged?.Invoke();
+                }
+            }
+        }
 
         /// <summary>
         /// If true, the audio will not be generated at the building process
@@ -27,7 +40,9 @@ namespace VRBuilder.Core.TextToSpeech
 
         private Type currentProviderType;
         private ITextToSpeechProvider currentProvider;
-        
+        [SerializeField]
+        private string provider;
+
         /// <summary>
         /// SettingsObject for the tts settings
         /// </summary>
@@ -35,20 +50,18 @@ namespace VRBuilder.Core.TextToSpeech
         {
             Provider = "MicrosoftSapiTextToSpeechProvider";
         }
-
+        
+        /// <summary>
+        /// Invoked when the text-to-speech provider changes
+        /// </summary>
+        public event Action ProviderChanged;
+        
         /// <summary>
         /// Loads the current TextToSpeechProvider
         /// </summary>
         /// <returns></returns>
         public ITextToSpeechProvider GetCurrentTextToSpeechProvider()
         {
-            // clear elements if a new provider is selected
-            if (currentProvider?.GetType().Name != Provider)
-            {
-                currentProviderType = null;
-                currentProvider = null;
-            }
-            
             currentProviderType ??= ReflectionUtils.GetConcreteImplementationsOf<ITextToSpeechProvider>().FirstOrDefault(type => type.Name == Provider);
             
             if (currentProviderType != null)

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -1,8 +1,9 @@
-using System.IO;
+using System;
+using System.Linq;
 using UnityEngine;
-using VRBuilder.Core.Configuration;
 using VRBuilder.Core.Settings;
-using VRBuilder.Core.TextToSpeech.Configuration;
+using VRBuilder.Core.TextToSpeech.Providers;
+using VRBuilder.Core.Utils;
 
 namespace VRBuilder.Core.TextToSpeech
 {
@@ -24,12 +25,38 @@ namespace VRBuilder.Core.TextToSpeech
         /// </summary>
         public string StreamingAssetCacheDirectoryName = "TextToSpeech";
 
+        private Type currentProviderType;
+        private ITextToSpeechProvider currentProvider;
+        
         /// <summary>
         /// SettingsObject for the tts settings
         /// </summary>
         public TextToSpeechSettings()
         {
             Provider = "MicrosoftSapiTextToSpeechProvider";
+        }
+
+        /// <summary>
+        /// Loads the current TextToSpeechProvider
+        /// </summary>
+        /// <returns></returns>
+        public ITextToSpeechProvider GetCurrentTextToSpeechProvider()
+        {
+            // clear elements if a new provider is selected
+            if (currentProvider?.GetType().Name != Provider)
+            {
+                currentProviderType = null;
+                currentProvider = null;
+            }
+            
+            currentProviderType ??= ReflectionUtils.GetConcreteImplementationsOf<ITextToSpeechProvider>().FirstOrDefault(type => type.Name == Provider);
+            
+            if (currentProviderType != null)
+            {
+                currentProvider ??= (ITextToSpeechProvider)Activator.CreateInstance(currentProviderType);
+            }
+
+            return currentProvider;
         }
     }
 }

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Linq;
-using Source.Core.Runtime.TextToSpeech.Utils.VRBuilder.Core.TextToSpeech;
 using UnityEngine;
 using VRBuilder.Core.Settings;
 using VRBuilder.Core.TextToSpeech.Providers;
-using VRBuilder.Core.Utils;
 
 namespace VRBuilder.Core.TextToSpeech
 {

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -85,7 +85,7 @@ namespace VRBuilder.Core.TextToSpeech
             Provider = "MicrosoftSapiTextToSpeechProvider";
             if (voiceProfiles.Length == 0)
             {
-                voiceProfiles = new[] { new VoiceProfile("Default", new[] { "all" }, "", new[] { "MicrosoftSapiTextToSpeechProvider" }) };
+                voiceProfiles = new[] { new VoiceProfile("Default", new[] { "all" }, "None Voice Selectable", new[] { "MicrosoftSapiTextToSpeechProvider" }) };
             }
         }
         

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -103,16 +103,11 @@ namespace VRBuilder.Core.TextToSpeech
         /// </summary>
         public string GetVoiceId(string profileName, string languageCode, string providerName)
         {
-            // First try to find the profile by name
-            var profile = voiceProfiles.FirstOrDefault(p => p.DisplayName == profileName);
-
+            // Try to find the profile by name
             // If not found, try the default profile
-            if (profile == null)
-            {
-                profile = voiceProfiles.FirstOrDefault(p => p.DisplayName == "Default");
-            }
+            var profile = voiceProfiles.FirstOrDefault(p => p.DisplayName == profileName) ?? voiceProfiles.FirstOrDefault(p => p.DisplayName == "Default");
 
-            // If still no profile, use the default behavior (empty voice ID)
+            // If still no profile, use the default
             if (profile == null)
             {
                 return string.Empty;
@@ -128,7 +123,7 @@ namespace VRBuilder.Core.TextToSpeech
                 }
             }
 
-            // Fallback: search for any profile that matches language and provider
+            // Search for any profile that matches the language and provider
             return GetVoiceIdForLanguage(languageCode, providerName);
         }
 
@@ -137,7 +132,7 @@ namespace VRBuilder.Core.TextToSpeech
         /// </summary>
         public string GetVoiceIdForLanguage(string languageCode, string providerName)
         {
-            // First try to find a profile that matches both language and provider
+            // Try to find a profile that matches both language and provider
             var profile = voiceProfiles.FirstOrDefault(p =>
                 (p.LanguageCode.Contains(languageCode) || p.LanguageCode.Contains("all")) &&
                 p.ProviderVoiceMappings.Any(m => m.ProviderName == providerName));
@@ -147,15 +142,14 @@ namespace VRBuilder.Core.TextToSpeech
                 return profile.ProviderVoiceMappings.First(m => m.ProviderName == providerName).VoiceId;
             }
 
+            Debug.LogWarning($"No voice ID for language {languageCode} and provider {providerName} found. Using other profiles that contains the provider.");
+            
             // If no exact match, try profiles that include the provider in their list
             profile = voiceProfiles.FirstOrDefault(p =>
                 (p.LanguageCode.Contains(languageCode) || p.LanguageCode.Contains("all")) &&
                 p.ProviderVoiceMappings.Count > 0);
 
-            if (profile != null)
-                return profile.ProviderVoiceMappings[0].VoiceId;
-
-            return string.Empty;
+            return profile != null ? profile.ProviderVoiceMappings[0].VoiceId : string.Empty;
         }
 
         /// <summary>

--- a/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
+++ b/Source/Core/Runtime/TextToSpeech/TextToSpeechSettings.cs
@@ -35,7 +35,13 @@ namespace VRBuilder.Core.TextToSpeech
                 }
             }
         }
-
+        
+        /// <summary>
+        /// StreamingAsset directory name which is used to load/save audio files.
+        /// </summary>
+        [SerializeField]
+        public string StreamingAssetCacheDirectoryName = "TextToSpeech";
+        
         /// <summary>
         /// If true, the audio will not be generated at the building process
         /// </summary>
@@ -43,11 +49,11 @@ namespace VRBuilder.Core.TextToSpeech
         public bool GenerateAudioInBuildingProcess = true;
         
         /// <summary>
-        /// StreamingAsset directory name which is used to load/save audio files.
+        /// If true, the existing audiofiles for text to speech generation would be ignored 
         /// </summary>
         [SerializeField]
-        public string StreamingAssetCacheDirectoryName = "TextToSpeech";
-
+        public bool IgnoreExistingTextToSpeechFiles = false;
+        
         /// <summary>
         /// List of voice profiles for TTS providers.
         /// </summary>

--- a/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
@@ -22,11 +22,11 @@ namespace VRBuilder.Core.TextToSpeech.Utils
         /// <param name="locale">Used locale</param>
         /// <param name="format">Used file format</param>
         /// <returns></returns>
-        public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale, string format = "wav")
+        public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale, string speaker = "", string format = "wav")
         {
             return !LocalizationSettings.HasSettings || string.IsNullOrEmpty(key)
-                ? $"TTS_{locale.Identifier.Code}_{GetMd5Hash(text).Replace("-", "")}"
-                : $"TTS_{RuntimeConfigurator.Instance.GetProcessStringLocalizationTable()}_{key}_{locale.Identifier.Code}.{format}";
+                ? $"TTS_{(speaker != ""? $"{speaker}_": "")}{locale.Identifier.Code}_{GetMd5Hash(text).Replace("-", "")}.{format}"
+                : $"TTS_{(speaker != ""? $"{speaker}_": "")}{RuntimeConfigurator.Instance.GetProcessStringLocalizationTable()}_{key}_{locale.Identifier.Code}.{format}";
         }
 
         /// <summary>

--- a/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
@@ -12,24 +12,31 @@ namespace VRBuilder.Core.TextToSpeech.Utils
 {
     public static class TextToSpeechUtils
     {
+
         /// <summary>
         /// Get GetUniqueIdentifier to identify the text relative to the locale and hash value
         /// </summary>
-        /// <param name="key">(can be null) if there is a unique key provided</param>
-        /// <param name="text">Text to get the identifier</param>
-        /// <param name="md5Hash">Hashed text value</param>
+        /// <param name="configuration">Used text-to-speech provider configuration</param>
+        /// <param name="key">Key of the string of the localization table</param>
+        /// <param name="text">The text to be checked if key is not set</param>
         /// <param name="locale">Used locale</param>
-        /// <returns>A unique identifier of the text</returns>
+        /// <param name="format">Used file format</param>
+        /// <returns></returns>
         public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale, string format = "wav")
         {
-            return ((!LocalizationSettings.HasSettings || string.IsNullOrEmpty(key))
+            return !LocalizationSettings.HasSettings || string.IsNullOrEmpty(key)
                 ? $"TTS_{locale.Identifier.Code}_{GetMd5Hash(text).Replace("-", "")}"
-                : $"TTS_{locale.Identifier.Code}_{key}") + "." + format;
+                : $"TTS_{RuntimeConfigurator.Instance.GetProcessStringLocalizationTable()}_{key}_{locale.Identifier.Code}.{format}";
         }
 
         /// <summary>
         /// Get a full path based on a <paramref name="text"/> to produce speech from, and create a directory for that.
         /// </summary>
+        /// <param name="configuration">Current configuration</param>
+        /// <param name="key">Key of the string of the localization table</param>
+        /// <param name="text">The text to be checked if key is not set</param>
+        /// <param name="locale">Used locale</param>
+        /// <returns>True if the localizedContent in the chosen locale is cached</returns>
         public static string PrepareFilepathForText(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale)
         {
             string filename = configuration.GetUniqueTextToSpeechFilename(key, text, locale);
@@ -53,16 +60,7 @@ namespace VRBuilder.Core.TextToSpeech.Utils
 
             return cleared;
         }
-
-        /// <summary>
-        /// Check if the localizedContent in the chosen locale is cached
-        /// </summary>
-        /// <param name="locale">Used locale</param>
-        /// <param name="text">Content to be checked</param>
-        /// <returns>True if the localizedContent in the chosen locale is cached</returns>
-        // public static bool IsCached(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale)
-        //     => File.Exists(PrepareFilepathForText(configuration, key, text, locale));
-
+        
         /// <summary>
         /// The result comes in byte array, but there are actually short values inside (ranged from short.Min to short.Max).
         /// </summary>

--- a/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
@@ -12,7 +12,6 @@ namespace VRBuilder.Core.TextToSpeech.Utils
 {
     public static class TextToSpeechUtils
     {
-
         /// <summary>
         /// Get GetUniqueIdentifier to identify the text relative to the locale and hash value
         /// </summary>
@@ -25,8 +24,8 @@ namespace VRBuilder.Core.TextToSpeech.Utils
         public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale, string speaker = "", string format = "wav")
         {
             return !LocalizationSettings.HasSettings || string.IsNullOrEmpty(key)
-                ? $"TTS_{(speaker != ""? $"{speaker}_": "")}{locale.Identifier.Code}_{GetMd5Hash(text).Replace("-", "")}.{format}"
-                : $"TTS_{(speaker != ""? $"{speaker}_": "")}{RuntimeConfigurator.Instance.GetProcessStringLocalizationTable()}_{key}_{locale.Identifier.Code}.{format}";
+                ? $"TTS_{(speaker != "" ? $"{speaker}_" : "")}{locale.Identifier.Code}_{GetMd5Hash(text).Replace("-", "")}.{format}"
+                : $"TTS_{(speaker != "" ? $"{speaker}_" : "")}{RuntimeConfigurator.Instance.GetProcessStringLocalizationTable()}_{key}_{locale.Identifier.Code}.{format}";
         }
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace VRBuilder.Core.TextToSpeech.Utils
 
             return cleared;
         }
-        
+
         /// <summary>
         /// The result comes in byte array, but there are actually short values inside (ranged from short.Min to short.Max).
         /// </summary>

--- a/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/TextToSpeechUtils.cs
@@ -7,6 +7,7 @@ using UnityEngine.Localization;
 using UnityEngine.Localization.Settings;
 using VRBuilder.Core.Configuration;
 using VRBuilder.Core.TextToSpeech.Configuration;
+using VRBuilder.Core.Utils.Audio;
 
 namespace VRBuilder.Core.TextToSpeech.Utils
 {
@@ -16,9 +17,23 @@ namespace VRBuilder.Core.TextToSpeech.Utils
         /// Get GetUniqueIdentifier to identify the text relative to the locale and hash value
         /// </summary>
         /// <param name="configuration">Used text-to-speech provider configuration</param>
+        /// <param name="audioData">Used audio data with meta-information</param>
+        /// <param name="locale">Used locale</param>
+        /// <param name="format">Used file format</param>
+        /// <returns></returns>
+        public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, ITextToSpeechContent audioData, Locale locale, string format = "wav")
+        {
+            return GetUniqueTextToSpeechFilename(configuration, audioData.Text, audioData.Text, locale, audioData.Speaker, format);
+        }
+
+        /// <summary>
+        /// Get GetUniqueIdentifier to identify the text relative to the locale and hash value
+        /// </summary>
+        /// <param name="configuration">Used text-to-speech provider configuration</param>
         /// <param name="key">Key of the string of the localization table</param>
         /// <param name="text">The text to be checked if key is not set</param>
         /// <param name="locale">Used locale</param>
+        /// <param name="speaker">Used speaker</param>
         /// <param name="format">Used file format</param>
         /// <returns></returns>
         public static string GetUniqueTextToSpeechFilename(this ITextToSpeechConfiguration configuration, string key, string text, Locale locale, string speaker = "", string format = "wav")

--- a/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
@@ -1,0 +1,79 @@
+namespace Source.Core.Runtime.TextToSpeech.Utils
+{
+    using System;
+    using UnityEngine;
+
+    namespace VRBuilder.Core.TextToSpeech
+    {
+        /// <summary>
+        /// Represents a voice profile that maps a display name to a specific voice ID for a TTS provider and language.
+        /// </summary>
+        [Serializable]
+        public class VoiceProfile
+        {
+            /// <summary>
+            /// Display name of the profile (e.g., "Marcello", "Markus").
+            /// </summary>
+            [SerializeField]
+            private string displayName;
+
+            /// <summary>
+            /// ISO language code (e.g., "de-DE", "en-US").
+            /// </summary>
+            [SerializeField]
+            private string[] languageCode;
+
+            /// <summary>
+            /// Voice ID specific to the TTS provider.
+            /// </summary>
+            [SerializeField]
+            private string voiceId;
+
+            /// <summary>
+            /// Name of the TTS provider this profile is for.
+            /// </summary>
+            [SerializeField]
+            private string providerName;
+
+            public string DisplayName
+            {
+                get => displayName;
+                set => displayName = value;
+            }
+
+            public string[] LanguageCode
+            {
+                get => languageCode;
+                set => languageCode = value;
+            }
+
+            public string VoiceId
+            {
+                get => voiceId;
+                set => voiceId = value;
+            }
+
+            public string ProviderName
+            {
+                get => providerName;
+                set => providerName = value;
+            }
+
+            public VoiceProfile()
+            {
+                displayName = "New Profile";
+                languageCode = new []{"en-US"};
+                voiceId = "";
+                providerName = "";
+            }
+
+            public VoiceProfile(string displayName, string[] languageCode, string voiceId, string providerName)
+            {
+                this.displayName = displayName;
+                this.languageCode = languageCode;
+                this.voiceId = voiceId;
+                this.providerName = providerName;
+            }
+        }
+    }
+}

--- a/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
@@ -1,91 +1,88 @@
-namespace Source.Core.Runtime.TextToSpeech.Utils
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace VRBuilder.Core.TextToSpeech
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using UnityEngine;
-
-    namespace VRBuilder.Core.TextToSpeech
+    [Serializable]
+    public class ProviderVoiceMapping
     {
-        [Serializable]
-        public class ProviderVoiceMapping
-        {
-            public string ProviderName;
-            public string VoiceId;
+        public string ProviderName;
+        public string VoiceId;
 
-            public ProviderVoiceMapping(string providerName, string voiceId)
-            {
-                ProviderName = providerName;
-                VoiceId = voiceId;
-            }
+        public ProviderVoiceMapping(string providerName, string voiceId)
+        {
+            ProviderName = providerName;
+            VoiceId = voiceId;
         }
+    }
+
+    /// <summary>
+    /// Represents a voice profile that maps a display name to a specific voice ID for a TTS provider and language.
+    /// </summary>
+    [Serializable]
+    public class VoiceProfile
+    {
+        /// <summary>
+        /// Display name of the profile (e.g., "Marcello", "Markus").
+        /// </summary>
+        [SerializeField]
+        private string displayName;
 
         /// <summary>
-        /// Represents a voice profile that maps a display name to a specific voice ID for a TTS provider and language.
+        /// ISO language code (e.g., "de-DE", "en-US").
         /// </summary>
-        [Serializable]
-        public class VoiceProfile
+        [SerializeField]
+        private string[] languageCode;
+
+        /// <summary>
+        /// Mappings from provider names to voice IDs.
+        /// </summary>
+        [SerializeField]
+        private List<ProviderVoiceMapping> providerVoiceMappings;
+        
+        /// <summary>
+        /// Fallback provider if there is no avaibled provider for multiple voices
+        /// </summary>
+        private string fallbackProviderName;
+
+        public string DisplayName
         {
-            /// <summary>
-            /// Display name of the profile (e.g., "Marcello", "Markus").
-            /// </summary>
-            [SerializeField]
-            private string displayName;
+            get => displayName;
+            set => displayName = value;
+        }
 
-            /// <summary>
-            /// ISO language code (e.g., "de-DE", "en-US").
-            /// </summary>
-            [SerializeField]
-            private string[] languageCode;
+        public string[] LanguageCode
+        {
+            get => languageCode;
+            set => languageCode = value;
+        }
 
-            /// <summary>
-            /// Mappings from provider names to voice IDs.
-            /// </summary>
-            [SerializeField]
-            private List<ProviderVoiceMapping> providerVoiceMappings;
-            
-            /// <summary>
-            /// Fallback provider if there is no avaibled provider for multiple voices
-            /// </summary>
-            private string fallbackProviderName;
+        public List<ProviderVoiceMapping> ProviderVoiceMappings
+        {
+            get => providerVoiceMappings;
+            set => providerVoiceMappings = value;
+        }
 
-            public string DisplayName
-            {
-                get => displayName;
-                set => displayName = value;
-            }
+        public string FallbackProviderName
+        {
+            get => fallbackProviderName; 
+            set => fallbackProviderName = value;
+        }
 
-            public string[] LanguageCode
-            {
-                get => languageCode;
-                set => languageCode = value;
-            }
+        public VoiceProfile()
+        {
+            displayName = "New Profile";
+            languageCode = new []{"all"};
+            providerVoiceMappings = new List<ProviderVoiceMapping>();
+        }
 
-            public List<ProviderVoiceMapping> ProviderVoiceMappings
-            {
-                get => providerVoiceMappings;
-                set => providerVoiceMappings = value;
-            }
-
-            public string FallbackProviderName
-            {
-                get => fallbackProviderName; 
-                set => fallbackProviderName = value;
-            }
-
-            public VoiceProfile()
-            {
-                displayName = "New Profile";
-                languageCode = new []{"all"};
-                providerVoiceMappings = new List<ProviderVoiceMapping>();
-            }
-
-            public VoiceProfile(string displayName, string[] languageCode, string voiceId, string[] providerNames)
-            {
-                this.displayName = displayName;
-                this.languageCode = languageCode;
-                this.providerVoiceMappings = providerNames.Select(p => new ProviderVoiceMapping(p, voiceId)).ToList();
-            }
+        public VoiceProfile(string displayName, string[] languageCode, string voiceId, string[] providerNames)
+        {
+            this.displayName = displayName;
+            this.languageCode = languageCode;
+            this.providerVoiceMappings = providerNames.Select(p => new ProviderVoiceMapping(p, voiceId)).ToList();
         }
     }
 }

--- a/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
@@ -1,10 +1,25 @@
 namespace Source.Core.Runtime.TextToSpeech.Utils
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using UnityEngine;
 
     namespace VRBuilder.Core.TextToSpeech
     {
+        [Serializable]
+        public class ProviderVoiceMapping
+        {
+            public string ProviderName;
+            public string VoiceId;
+
+            public ProviderVoiceMapping(string providerName, string voiceId)
+            {
+                ProviderName = providerName;
+                VoiceId = voiceId;
+            }
+        }
+
         /// <summary>
         /// Represents a voice profile that maps a display name to a specific voice ID for a TTS provider and language.
         /// </summary>
@@ -24,16 +39,10 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
             private string[] languageCode;
 
             /// <summary>
-            /// Voice ID specific to the TTS provider.
+            /// Mappings from provider names to voice IDs.
             /// </summary>
             [SerializeField]
-            private string voiceId;
-
-            /// <summary>
-            /// Name of the TTS provider this profile is for.
-            /// </summary>
-            [SerializeField]
-            private string[] providerNames;
+            private List<ProviderVoiceMapping> providerVoiceMappings;
             
             /// <summary>
             /// Fallback provider if there is no avaibled provider for multiple voices
@@ -52,16 +61,10 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
                 set => languageCode = value;
             }
 
-            public string VoiceId
+            public List<ProviderVoiceMapping> ProviderVoiceMappings
             {
-                get => voiceId;
-                set => voiceId = value;
-            }
-
-            public string[] ProviderNames
-            {
-                get => providerNames;
-                set => providerNames = value;
+                get => providerVoiceMappings;
+                set => providerVoiceMappings = value;
             }
 
             public string FallbackProviderName
@@ -73,17 +76,15 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
             public VoiceProfile()
             {
                 displayName = "New Profile";
-                languageCode = new []{"en-US"};
-                voiceId = "";
-                providerNames = new []{""};
+                languageCode = new []{"all"};
+                providerVoiceMappings = new List<ProviderVoiceMapping>();
             }
 
             public VoiceProfile(string displayName, string[] languageCode, string voiceId, string[] providerNames)
             {
                 this.displayName = displayName;
                 this.languageCode = languageCode;
-                this.voiceId = voiceId;
-                this.providerNames = providerNames;
+                this.providerVoiceMappings = providerNames.Select(p => new ProviderVoiceMapping(p, voiceId)).ToList();
             }
         }
     }

--- a/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
+++ b/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs
@@ -33,7 +33,12 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
             /// Name of the TTS provider this profile is for.
             /// </summary>
             [SerializeField]
-            private string providerName;
+            private string[] providerNames;
+            
+            /// <summary>
+            /// Fallback provider if there is no avaibled provider for multiple voices
+            /// </summary>
+            private string fallbackProviderName;
 
             public string DisplayName
             {
@@ -53,10 +58,16 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
                 set => voiceId = value;
             }
 
-            public string ProviderName
+            public string[] ProviderNames
             {
-                get => providerName;
-                set => providerName = value;
+                get => providerNames;
+                set => providerNames = value;
+            }
+
+            public string FallbackProviderName
+            {
+                get => fallbackProviderName; 
+                set => fallbackProviderName = value;
             }
 
             public VoiceProfile()
@@ -64,15 +75,15 @@ namespace Source.Core.Runtime.TextToSpeech.Utils
                 displayName = "New Profile";
                 languageCode = new []{"en-US"};
                 voiceId = "";
-                providerName = "";
+                providerNames = new []{""};
             }
 
-            public VoiceProfile(string displayName, string[] languageCode, string voiceId, string providerName)
+            public VoiceProfile(string displayName, string[] languageCode, string voiceId, string[] providerNames)
             {
                 this.displayName = displayName;
                 this.languageCode = languageCode;
                 this.voiceId = voiceId;
-                this.providerName = providerName;
+                this.providerNames = providerNames;
             }
         }
     }

--- a/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs.meta
+++ b/Source/Core/Runtime/TextToSpeech/Utils/VoiceProfile.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 030c8fbd8ec4494d9ea93da5c41e2784
+timeCreated: 1768402992


### PR DESCRIPTION
Added a new approach for using different voices as speaker in the Text-to-speech behavior in VR Builder.

A new data class as well as a new data property in the behavior was created. The default case of this feature will not visible if no text-to-speech provider is available. So the core workflow and runtime is unchanged here.

The mentioned bug in [Issues 337](https://github.com/MindPort-GmbH/VR-Builder/issues/337) is fixed here as well.