### PR TITLE
Add "Move to Top" Option for Behaviors

### DIFF
--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -616,7 +616,8 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
             return valueDrawer.Draw(rect, listOfWrappers, (newValue) =>
             {
-                IList<MetadataWrapper> newListOfWrappers = (IList<MetadataWrapper>)newValue;
+                IList<MetadataWrapper> inputWrappers = (IList<MetadataWrapper>)newValue;
+                List<MetadataWrapper> newListOfWrappers = new List<MetadataWrapper>(inputWrappers);
 
                 for (int i = 0; i < newListOfWrappers.Count; i++)
                 {
@@ -630,6 +631,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                                 newListOfWrappers.RemoveAt(i);
                                 newListOfWrappers.Insert(0, oldElement);
                             }
+                            // No i-- needed: index i now holds an element that was already processed earlier.
                             break;
                         case ReorderAction.MoveDown:
                             if (i < newListOfWrappers.Count - 1)

--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -216,6 +216,19 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 menu.AddDisabledItem(new GUIContent("Paste"));
             }
 
+            if (wrapper.Value is IBehavior && wrapper.Metadata.TryGetValue(reorderableName, out object reorderableMetadataObject) &&
+                reorderableMetadataObject is ReorderableElementMetadata reorderableMetadata)
+            {
+                if (reorderableMetadata.IsFirst == false)
+                {
+                    menu.AddItem(new GUIContent("Move to Top"), false, () => MoveToTop(wrapper, changeValueCallback));
+                }
+                else
+                {
+                    menu.AddDisabledItem(new GUIContent("Move to Top"));
+                }
+            }
+
             menu.ShowAsContext();
         }
 
@@ -609,7 +622,17 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 {
                     ReorderableElementMetadata metadata = (ReorderableElementMetadata)newListOfWrappers[i].Metadata[reorderableName];
 
-                    if (metadata.MoveDown && metadata.MoveUp == false)
+                    if (metadata.MoveToTop && metadata.MoveDown == false && metadata.MoveUp == false)
+                    {
+                        metadata.MoveToTop = false;
+                        if (i > 0)
+                        {
+                            MetadataWrapper oldElement = newListOfWrappers[i];
+                            newListOfWrappers.RemoveAt(i);
+                            newListOfWrappers.Insert(0, oldElement);
+                        }
+                    }
+                    else if (metadata.MoveDown && metadata.MoveUp == false && metadata.MoveToTop == false)
                     {
                         metadata.MoveDown = false;
                         if (i < newListOfWrappers.Count - 1)
@@ -634,7 +657,8 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                     }
                     else
                     {
-                        // Reset, if both actions are true
+                        // Reset, if multiple actions are true.
+                        metadata.MoveToTop = false;
                         metadata.MoveDown = false;
                         metadata.MoveUp = false;
                     }
@@ -716,6 +740,35 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             }
 
             return rect;
+        }
+
+        private void MoveToTop(MetadataWrapper wrapper, Action<object> changeValueCallback)
+        {
+            if (wrapper.Metadata.TryGetValue(reorderableName, out object reorderableMetadataObject) == false ||
+                reorderableMetadataObject is ReorderableElementMetadata == false)
+            {
+                return;
+            }
+
+            ReorderableElementMetadata reorderableMetadata = (ReorderableElementMetadata)reorderableMetadataObject;
+            if (reorderableMetadata.IsFirst)
+            {
+                return;
+            }
+
+            object oldValue = wrapper.Value;
+            ChangeValue(() =>
+                {
+                    reorderableMetadata.MoveToTop = true;
+                    return wrapper;
+                },
+                () =>
+                {
+                    reorderableMetadata.MoveToTop = false;
+                    wrapper.Value = oldValue;
+                    return wrapper;
+                },
+                changeValueCallback);
         }
 
         private void Delete(MetadataWrapper wrapper, Action<object> changeValueCallback)

--- a/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -246,12 +246,12 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 object oldValue = wrapper.Value;
                 ChangeValue(() =>
                     {
-                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).MoveDown = true;
+                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).PendingAction = ReorderAction.MoveDown;
                         return wrapper;
                     },
                     () =>
                     {
-                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).MoveDown = false;
+                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).PendingAction = ReorderAction.None;
                         wrapper.Value = oldValue;
                         return wrapper;
                     },
@@ -265,12 +265,12 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 object oldValue = wrapper.Value;
                 ChangeValue(() =>
                     {
-                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).MoveUp = true;
+                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).PendingAction = ReorderAction.MoveUp;
                         return wrapper;
                     },
                     () =>
                     {
-                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).MoveUp = false;
+                        ((ReorderableElementMetadata)wrapper.Metadata[reorderableName]).PendingAction = ReorderAction.None;
                         wrapper.Value = oldValue;
                         return wrapper;
                     },
@@ -621,47 +621,38 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 for (int i = 0; i < newListOfWrappers.Count; i++)
                 {
                     ReorderableElementMetadata metadata = (ReorderableElementMetadata)newListOfWrappers[i].Metadata[reorderableName];
+                    switch (metadata.PendingAction)
+                    {
+                        case ReorderAction.MoveToTop:
+                            if (i > 0)
+                            {
+                                MetadataWrapper oldElement = newListOfWrappers[i];
+                                newListOfWrappers.RemoveAt(i);
+                                newListOfWrappers.Insert(0, oldElement);
+                            }
+                            break;
+                        case ReorderAction.MoveDown:
+                            if (i < newListOfWrappers.Count - 1)
+                            {
+                                MetadataWrapper oldElement = newListOfWrappers[i];
+                                newListOfWrappers[i] = newListOfWrappers[i + 1];
+                                newListOfWrappers[i + 1] = oldElement;
 
-                    if (metadata.MoveToTop && metadata.MoveDown == false && metadata.MoveUp == false)
-                    {
-                        metadata.MoveToTop = false;
-                        if (i > 0)
-                        {
-                            MetadataWrapper oldElement = newListOfWrappers[i];
-                            newListOfWrappers.RemoveAt(i);
-                            newListOfWrappers.Insert(0, oldElement);
-                        }
+                                // Repeat at same index because unprocessed element switched position to i.
+                                i--;
+                            }
+                            break;
+                        case ReorderAction.MoveUp:
+                            if (i > 0)
+                            {
+                                MetadataWrapper oldElement = newListOfWrappers[i];
+                                newListOfWrappers[i] = newListOfWrappers[i - 1];
+                                newListOfWrappers[i - 1] = oldElement;
+                            }
+                            break;
                     }
-                    else if (metadata.MoveDown && metadata.MoveUp == false && metadata.MoveToTop == false)
-                    {
-                        metadata.MoveDown = false;
-                        if (i < newListOfWrappers.Count - 1)
-                        {
-                            MetadataWrapper oldElement = newListOfWrappers[i];
-                            newListOfWrappers[i] = newListOfWrappers[i + 1];
-                            newListOfWrappers[i + 1] = oldElement;
-                        }
 
-                        // Repeat at same index because unprocessed element switched position to i.
-                        i--;
-                    }
-                    else if (metadata.MoveDown == false && metadata.MoveUp)
-                    {
-                        metadata.MoveUp = false;
-                        if (i > 0)
-                        {
-                            MetadataWrapper oldElement = newListOfWrappers[i];
-                            newListOfWrappers[i] = newListOfWrappers[i - 1];
-                            newListOfWrappers[i - 1] = oldElement;
-                        }
-                    }
-                    else
-                    {
-                        // Reset, if multiple actions are true.
-                        metadata.MoveToTop = false;
-                        metadata.MoveDown = false;
-                        metadata.MoveUp = false;
-                    }
+                    metadata.PendingAction = ReorderAction.None;
                 }
 
                 ReflectionUtils.ReplaceList(ref list, newListOfWrappers.Select(childWrapper => childWrapper.Value));
@@ -759,12 +750,12 @@ namespace VRBuilder.Core.Editor.UI.Drawers
             object oldValue = wrapper.Value;
             ChangeValue(() =>
                 {
-                    reorderableMetadata.MoveToTop = true;
+                    reorderableMetadata.PendingAction = ReorderAction.MoveToTop;
                     return wrapper;
                 },
                 () =>
                 {
-                    reorderableMetadata.MoveToTop = false;
+                    reorderableMetadata.PendingAction = ReorderAction.None;
                     wrapper.Value = oldValue;
                     return wrapper;
                 },

--- a/Source/Core/Runtime/Metadata/ReorderableElementMetadata.cs
+++ b/Source/Core/Runtime/Metadata/ReorderableElementMetadata.cs
@@ -5,24 +5,25 @@
 namespace VRBuilder.Core.UI.Drawers.Metadata
 {
     /// <summary>
+    /// Pending reorder action for an item in a reorderable list.
+    /// </summary>
+    public enum ReorderAction
+    {
+        None,
+        MoveToTop,
+        MoveUp,
+        MoveDown
+    }
+
+    /// <summary>
     /// Metadata to make <see cref="VRBuilder.Core.Attributes.ReorderableListOfAttribute"/> reorderable.
     /// </summary>
     public class ReorderableElementMetadata
     {
         /// <summary>
-        /// Determines, whether the entity must be moved to the top in the list.
+        /// Reorder request queued by the UI and consumed by the reorder processing loop.
         /// </summary>
-        public bool MoveToTop { get; set; }
-
-        /// <summary>
-        /// Determines, whether the entity must be moved up in the list.
-        /// </summary>
-        public bool MoveUp { get; set; }
-
-        /// <summary>
-        /// Determines, whether the entity must be moved down in the list.
-        /// </summary>
-        public bool MoveDown { get; set; }
+        public ReorderAction PendingAction { get; set; }
 
         /// <summary>
         /// Determines, whether the entity is the first one in the list.

--- a/Source/Core/Runtime/Metadata/ReorderableElementMetadata.cs
+++ b/Source/Core/Runtime/Metadata/ReorderableElementMetadata.cs
@@ -10,6 +10,11 @@ namespace VRBuilder.Core.UI.Drawers.Metadata
     public class ReorderableElementMetadata
     {
         /// <summary>
+        /// Determines, whether the entity must be moved to the top in the list.
+        /// </summary>
+        public bool MoveToTop { get; set; }
+
+        /// <summary>
         /// Determines, whether the entity must be moved up in the list.
         /// </summary>
         public bool MoveUp { get; set; }


### PR DESCRIPTION
# Add "Move to Top" Option for Behaviors

## Description
This PR introduces a **"Move to Top"** feature in the behavior context menu, allowing users to quickly navigate newly created behaviors to the top of the list.

## Key Changes

### Move to Top Feature
Added a **"Move to Top"** context menu action in `MetadataWrapperDrawer.cs`.

### Reordering Logic
Added the necessary logic to process the **"Move to Top"** action, moving the target behavior to the first position without affecting other elements.

---

## Campsite Rule Refactoring

In the spirit of the **"campsite rule"** (leaving the code cleaner than we found it), the existing reordering logic was also refactored to improve readability:

- Replaced the overlapping boolean flags (`MoveToTop`, `MoveUp`, `MoveDown`) in `ReorderableElementMetadata.cs` with a unified `ReorderAction` enum.
- Replaced the nested and chained `if-else` statements in `DrawReorderableListOf` with a streamlined `switch` statement that correctly addresses the `PendingAction`.

## Demonstration

https://github.com/user-attachments/assets/4852721f-7d8c-4b4f-b2b5-9a86b4541620


