### PR TITLE
String filter for Scene Object Group Settings page

### DIFF
--- a/Source/Core/Editor/UI/ProjectSettings/SceneObjectGroupsSettingsSection.cs
+++ b/Source/Core/Editor/UI/ProjectSettings/SceneObjectGroupsSettingsSection.cs
@@ -52,9 +52,17 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
 
+            string filterText = newLabel?.Trim();
+            bool hasFilter = string.IsNullOrEmpty(filterText) == false;
+
             // List all groups
             foreach (SceneObjectGroups.SceneObjectGroup group in config.Groups)
             {
+                if (hasFilter && (group.Label?.Contains(filterText, StringComparison.OrdinalIgnoreCase) ?? false) == false)
+                {
+                    continue;
+                }
+
                 if (foldoutStatus.ContainsKey(group) == false)
                 {
                     foldoutStatus.Add(group, false);
@@ -81,14 +89,14 @@ namespace VRBuilder.Core.Editor.UI.ProjectSettings
                 // Label field
                 EditorGUI.BeginChangeCheck();
 
-                string newLabel = EditorGUILayout.TextField(label);
+                string editedLabel = EditorGUILayout.TextField(label);
 
                 if (EditorGUI.EndChangeCheck())
                 {
-                    if (string.IsNullOrEmpty(newLabel) == false && newLabel != label)
+                    if (string.IsNullOrEmpty(editedLabel) == false && editedLabel != label)
                     {
                         Undo.RecordObject(config, "Renamed group");
-                        config.RenameGroup(group, newLabel);
+                        config.RenameGroup(group, editedLabel);
                         EditorUtility.SetDirty(config);
                     }
                 }

--- a/Source/Core/Runtime/Settings/SceneObjectGroups.cs
+++ b/Source/Core/Runtime/Settings/SceneObjectGroups.cs
@@ -26,7 +26,7 @@ namespace VRBuilder.Core.Settings
             /// </summary>
             /// <remarks>
             /// We do not guarantee that this name is unique.
-            /// </remarks> 
+            /// </remarks>
             public string Label => label;
 
             [SerializeField]
@@ -162,7 +162,7 @@ namespace VRBuilder.Core.Settings
         /// Retrieves the label of a <seealso cref="SceneObjectGroup"/> based on its GUID.
         /// </summary>
         /// <param name="guid">The GUID of the <seealso cref="SceneObjectGroup"/> .</param>
-        /// <returns>The label of the <seealso cref="SceneObjectGroup"/> if a group with the specified GUID is found; otherwise, <c>string.Empty</c>.</returns> 
+        /// <returns>The label of the <seealso cref="SceneObjectGroup"/> if a group with the specified GUID is found; otherwise, <c>string.Empty</c>.</returns>
         public string GetLabel(Guid guid)
         {
             if (GroupExists(guid))


### PR DESCRIPTION
- Add string filter functionality to Scene Object Group Settings page
- Filter groups by label using case-insensitive substring matching

<img width="784" height="556" alt="image" src="https://github.com/user-attachments/assets/a0cdac9f-8259-42ce-ab2f-7066a1cc3868" />
<img width="785" height="552" alt="image" src="https://github.com/user-attachments/assets/84337da9-124c-4250-b818-68a9ae1a2684" />