### PR TITLE
fix(xr-interaction): respect negative poke direction in pokable depth pipeline

### DIFF
--- a/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
@@ -37,7 +37,7 @@ namespace VRBuilder.BasicInteraction.Conditions
             private float requiredHoldDuration;
 
             [DataMember]
-            [DisplayName("Poke Depth")]
+            [DisplayName("Poke Depth (0 to 1)")]
             public float PokeDepthThreshold
             {
                 get => pokeDepthThreshold;

--- a/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
@@ -41,7 +41,7 @@ namespace VRBuilder.BasicInteraction.Conditions
             public float PokeDepthThreshold
             {
                 get => pokeDepthThreshold;
-                set => pokeDepthThreshold = Mathf.Max(value, 0f);
+                set => pokeDepthThreshold = Mathf.Clamp01(value);
             }
 
             [DataMember]
@@ -138,7 +138,6 @@ namespace VRBuilder.BasicInteraction.Conditions
             private bool CheckDepthMet()
             {
                 float threshold = Data.PokeDepthThreshold - DepthTolerance;
-
                 if (Data.MustPokeAllObjects)
                 {
                     return Data.PokableProperties.Values.All(

--- a/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
@@ -37,7 +37,8 @@ namespace VRBuilder.BasicInteraction.Conditions
             private float requiredHoldDuration;
 
             [DataMember]
-            [DisplayName("Poke Depth (0 to 1)")]
+            [DisplayName("Poke Depth (from 0 to 1)")]
+            [UsesSpecificProcessDrawer("NormalizedFloatDrawer")]
             public float PokeDepthThreshold
             {
                 get => pokeDepthThreshold;

--- a/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/PokedCondition.cs
@@ -33,7 +33,7 @@ namespace VRBuilder.BasicInteraction.Conditions
             [DisplayName("All objects required to be poked")]
             public bool MustPokeAllObjects { get; set; }
 
-            private float pokeDepthThreshold;
+            private float pokeDepthThreshold = 1f;
             private float requiredHoldDuration;
 
             [DataMember]

--- a/Source/BasicInteraction/Runtime/Properties/IPokableProperty.cs
+++ b/Source/BasicInteraction/Runtime/Properties/IPokableProperty.cs
@@ -28,8 +28,8 @@ namespace VRBuilder.BasicInteraction.Properties
         bool IsBeingPoked { get; }
 
         /// <summary>
-        /// Current poke depth from 0 (no contact) to 1 (fully pressed).
-        /// Updated every frame from XRPokeFilter's pokeStateData.
+        /// Current poke press progress from 0 (no press) to 1 (fully pressed).
+        /// Updated every frame from XRPokeFilter's pokeStateData interaction strength.
         /// </summary>
         float CurrentPokeDepth { get; }
 

--- a/Source/XRInteraction/Source/Runtime/Properties/PokableProperty.cs
+++ b/Source/XRInteraction/Source/Runtime/Properties/PokableProperty.cs
@@ -14,8 +14,6 @@ namespace VRBuilder.XRInteraction.Properties
     [RequireComponent(typeof(XRSimpleInteractable), typeof(XRPokeFilter))]
     public class PokableProperty : LockableProperty, IPokableProperty
     {
-        private const float PokeDepthEpsilon = 0.0001f;
-
         [Header("Events")]
         [SerializeField]
         private UnityEvent<PokablePropertyEventArgs> pokeStarted = new UnityEvent<PokablePropertyEventArgs>();
@@ -123,7 +121,7 @@ namespace VRBuilder.XRInteraction.Properties
         private void OnPokeStateDataUpdated(PokeStateData data)
         {
             float depth = Mathf.Clamp01(data.interactionStrength);
-            bool hasActivePoke = data.target != null && depth > PokeDepthEpsilon;
+            bool hasActivePoke = data.target != null && depth > 0f;
 
             currentPokeDepth = hasActivePoke ? depth : 0f;
 

--- a/Source/XRInteraction/Source/Runtime/Properties/PokableProperty.cs
+++ b/Source/XRInteraction/Source/Runtime/Properties/PokableProperty.cs
@@ -14,6 +14,8 @@ namespace VRBuilder.XRInteraction.Properties
     [RequireComponent(typeof(XRSimpleInteractable), typeof(XRPokeFilter))]
     public class PokableProperty : LockableProperty, IPokableProperty
     {
+        private const float PokeDepthEpsilon = 0.0001f;
+
         [Header("Events")]
         [SerializeField]
         private UnityEvent<PokablePropertyEventArgs> pokeStarted = new UnityEvent<PokablePropertyEventArgs>();
@@ -120,25 +122,23 @@ namespace VRBuilder.XRInteraction.Properties
 
         private void OnPokeStateDataUpdated(PokeStateData data)
         {
-            if (data.target == null)
-            {
-                currentPokeDepth = 0f;
+            float depth = Mathf.Clamp01(data.interactionStrength);
+            bool hasActivePoke = data.target != null && depth > PokeDepthEpsilon;
 
-                if (IsBeingPoked)
+            currentPokeDepth = hasActivePoke ? depth : 0f;
+
+            if (hasActivePoke)
+            {
+                if (!IsBeingPoked)
                 {
-                    IsBeingPoked = false;
-                    EmitUnpoked();
+                    IsBeingPoked = true;
+                    EmitPoked();
                 }
-
-                return;
             }
-
-            currentPokeDepth = 1f - data.interactionStrength;
-
-            if (!IsBeingPoked)
+            else if (IsBeingPoked)
             {
-                IsBeingPoked = true;
-                EmitPoked();
+                IsBeingPoked = false;
+                EmitUnpoked();
             }
         }
 


### PR DESCRIPTION
<img width="664" height="218" alt="image" src="https://github.com/user-attachments/assets/df15db75-2609-4a96-a998-8632f250d7f0" />


- use `PokeStateData.interactionStrength` as press-progress depth in `PokableProperty`
- clamp `PokedCondition.PokeDepthThreshold` to `[0, 1]`
- align `IPokableProperty` depth documentation with press-progress semantics
- set default poke value to 1 as it should be IMO the default  
- set [DisplayName("Poke Depth (0 to 1)")] to explain min max

Note: added tests in test repo