### PR TITLE
Prevent additive scene load from reloading process editor

### DIFF
--- a/Source/Core/Editor/GlobalEditorHandler.cs
+++ b/Source/Core/Editor/GlobalEditorHandler.cs
@@ -212,6 +212,12 @@ namespace VRBuilder.Core.Editor
 
             string processName = System.IO.Path.GetFileNameWithoutExtension(processPath);
 
+            IProcess currentProcess = GetCurrentProcess();
+            if (currentProcess?.Data?.Name == processName)
+            {
+                return;
+            }
+
             SetCurrentProcess(processName);
         }
     }


### PR DESCRIPTION
## Summary
- skip `SetCurrentProcess` when additive scene points to process already open in editor
- preserve unsaved process editor changes during additive scene load
- keep reload path for actual process changes intact

## Verification
- reproducer reviewed against `GlobalEditorHandler.OnSceneOpened`
- paired with regression tests in VR-Builder-Tests PR for VRB-3754