### PR TITLE
[codex] Preserve component selection for unloaded additive scenes

### DIFF
--- a/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs
@@ -14,6 +14,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     public class SetComponentEnabledBehaviorDrawer : NameableDrawer
     {
         private const string noComponentSelected = "<none>";
+        private const string unavailableSuffix = " (unavailable)";
 
         internal sealed class ComponentTypeSelection
         {
@@ -127,7 +128,7 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 .Select(componentType => string.IsNullOrEmpty(componentType)
                     ? noComponentSelected
                     : isSelectedTypeUnavailable && componentType == selectedComponentType
-                        ? $"{componentType} (unavailable)"
+                        ? $"{componentType}{unavailableSuffix}"
                         : componentType)
                 .ToList();
 

--- a/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs
+++ b/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs
@@ -15,6 +15,22 @@ namespace VRBuilder.Core.Editor.UI.Drawers
     {
         private const string noComponentSelected = "<none>";
 
+        internal sealed class ComponentTypeSelection
+        {
+            public IReadOnlyList<string> Values { get; }
+            public IReadOnlyList<string> Labels { get; }
+            public int SelectedIndex { get; }
+            public bool IsSelectedTypeUnavailable { get; }
+
+            public ComponentTypeSelection(IReadOnlyList<string> values, IReadOnlyList<string> labels, int selectedIndex, bool isSelectedTypeUnavailable)
+            {
+                Values = values;
+                Labels = labels;
+                SelectedIndex = selectedIndex;
+                IsSelectedTypeUnavailable = isSelectedTypeUnavailable;
+            }
+        }
+
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
             rect = base.Draw(rect, currentValue, changeValueCallback, label);
@@ -42,25 +58,12 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                     .ToList();
             }
 
-            int currentComponent = 0;
+            ComponentTypeSelection componentTypeSelection = BuildComponentTypeSelection(
+                components.Select(component => component.GetType().Name),
+                data.ComponentType);
 
-            List<string> componentLabels = components.Select(c => c.GetType().Name).ToList();
-            componentLabels.Insert(0, noComponentSelected);
-
-            if (string.IsNullOrEmpty(data.ComponentType) == false)
-            {
-                if (componentLabels.Contains(data.ComponentType))
-                {
-                    currentComponent = componentLabels.IndexOf(componentLabels.First(l => l == data.ComponentType));
-                }
-                else
-                {
-                    currentComponent = 0;
-                    ChangeComponentType("", data, changeValueCallback);
-                }
-            }
-
-            int newComponent = EditorGUI.Popup(nextPosition, "Component type", currentComponent, componentLabels.ToArray());
+            int currentComponent = componentTypeSelection.SelectedIndex;
+            int newComponent = EditorGUI.Popup(nextPosition, "Component type", currentComponent, componentTypeSelection.Labels.ToArray());
 
             if (newComponent != currentComponent)
             {
@@ -72,13 +75,26 @@ namespace VRBuilder.Core.Editor.UI.Drawers
                 }
                 else
                 {
-                    ChangeComponentType(componentLabels[currentComponent], data, changeValueCallback);
+                    ChangeComponentType(componentTypeSelection.Values[currentComponent], data, changeValueCallback);
                 }
 
                 changeValueCallback(data);
             }
 
             height += EditorDrawingHelper.SingleLineHeight;
+
+            if (componentTypeSelection.IsSelectedTypeUnavailable)
+            {
+                height += EditorDrawingHelper.VerticalSpacing;
+                nextPosition.y = rect.y + height;
+                nextPosition.height = EditorDrawingHelper.SingleLineHeight * 2;
+                EditorGUI.HelpBox(
+                    nextPosition,
+                    $"Selected component type '{data.ComponentType}' is unavailable. The referenced scene may be unloaded or the component may have been removed.",
+                    MessageType.Warning);
+                height += nextPosition.height;
+            }
+
             height += EditorDrawingHelper.VerticalSpacing;
             nextPosition.y = rect.y + height;
 
@@ -91,6 +107,32 @@ namespace VRBuilder.Core.Editor.UI.Drawers
 
             rect.height = height;
             return rect;
+        }
+
+        internal static ComponentTypeSelection BuildComponentTypeSelection(IEnumerable<string> availableComponentTypes, string selectedComponentType)
+        {
+            List<string> values = new List<string> { string.Empty };
+            values.AddRange(availableComponentTypes
+                .Where(componentType => string.IsNullOrEmpty(componentType) == false)
+                .Distinct());
+
+            bool isSelectedTypeUnavailable = string.IsNullOrEmpty(selectedComponentType) == false && values.Contains(selectedComponentType) == false;
+
+            if (isSelectedTypeUnavailable)
+            {
+                values.Insert(1, selectedComponentType);
+            }
+
+            List<string> labels = values
+                .Select(componentType => string.IsNullOrEmpty(componentType)
+                    ? noComponentSelected
+                    : isSelectedTypeUnavailable && componentType == selectedComponentType
+                        ? $"{componentType} (unavailable)"
+                        : componentType)
+                .ToList();
+
+            int selectedIndex = string.IsNullOrEmpty(selectedComponentType) ? 0 : values.IndexOf(selectedComponentType);
+            return new ComponentTypeSelection(values, labels, selectedIndex, isSelectedTypeUnavailable);
         }
 
         private bool CanBeDisabled(Component component)


### PR DESCRIPTION
# Validation by Markus 
- Code Review
- Tested in Editor multi scene workflow problem fixed

# AI generated

## Summary

- preserve serialized `ComponentType` when target objects cannot resolve because an additive scene is unloaded
- display unavailable stored type in component dropdown instead of silently selecting `<none>`
- show warning for unresolved or removed component types
- keep explicit user-driven clearing and component changes unchanged

## Root cause

`SetComponentEnabledBehaviorDrawer` rebuilt dropdown options from currently resolved scene objects. When referenced additive scene was closed, stored component type was absent from generated labels and inspector draw called `ChangeComponentType("")`, mutating process data without user input.

## Impact

Fix applies to both Enable Component and Disable Component behaviors because both use `SetComponentEnabledBehaviorDrawer`.

## Validation

- Unity asset refresh and compilation: passed
- focused EditMode regression tests in companion Tests PR: 5 passed, 0 failed
- `VRBuilder.Core.Tests.EditMode`: 37 passed, 0 failed
- Play Mode entered and exited; only existing environment errors for Meta XR, unavailable DataHub server, and anchor loading occurred

Jira: [VRB-3756](https://mindport.atlassian.net/browse/VRB-3756)

[VRB-3756]: https://mindport.atlassian.net/browse/VRB-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Risk Evaluation

**What changed**
Old behavior cleared `data.ComponentType` during inspector draw when selected component type was unavailable.

**New behavior:**

- Builds separate serialized values and display labels ([line 112](C:/Unity/VIRTOSHA-VR-Builder-Sample/Packages/co.mindport.vrbuilder.core/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs:112)).
- Keeps unavailable stored type instead of replacing it with empty string.
- Adds unavailable type into dropdown as `TypeName (unavailable)`.
- Shows warning HelpBox ([line 86](C:/Unity/VIRTOSHA-VR-Builder-Sample/Packages/co.mindport.vrbuilder.core/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs:86)).
- Removes duplicate component type entries through `Distinct()`.
- Maps dropdown labels back to raw serialized values.

**Positive effect**

Opening inspector no longer mutates process data. Temporary scene unloading no longer destroys configured component type. Undo history also avoids unwanted automatic change.

**Possible side effects**
- Invalid configuration now persists. Runtime may attempt unavailable component type until user fixes selection. Better than silent data loss, but warning exists only in editor.
- Inspector height grows by two lines when type unavailable.
- Component order still follows target-object/component enumeration. `Distinct()` removes duplicates but does not sort.
- Type identity still uses `GetType().Name`, not full type name. Two components from different namespaces sharing class name remain indistinguishable. Existing limitation.
- Missing-script component can still produce `null`; `CanBeDisabled()` calls `component.GetType()` ([line 138](C:/Unity/VIRTOSHA-VR-Builder-Sample/Packages/co.mindport.vrbuilder.core/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs:138)), causing `NullReferenceException`. Existing limitation, but warning text mentions removed component.
- Selection change still invokes `changeValueCallback` twice: once inside `ChangeComponentType()`, once at [line 81](C:/Unity/VIRTOSHA-VR-Builder-Sample/Packages/co.mindport.vrbuilder.core/Source/Core/Editor/UI/Drawers/SetComponentEnabledBehaviorDrawer.cs:81). Existing behavior, not new regression.

Risk low. Main behavioral change intentional: preserve stale selection instead of silently clearing it.