### PR TITLE
feat: add SnapZone interactable attach transform override

### DIFF
--- a/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactables/InteractableObject.cs
@@ -164,6 +164,17 @@ namespace VRBuilder.XRInteraction.Interactables
             return isGrabbable && base.IsSelectableBy(interactor);
         }
 
+        /// <inheritdoc />
+        public override Transform GetAttachTransform(IXRInteractor interactor)
+        {
+            if (interactor is SnapZone snapZone && snapZone.IgnoreInteractableAttachTransform)
+            {
+                return transform;
+            }
+
+            return base.GetAttachTransform(interactor);
+        }
+
         /// <summary>
         /// Forces all hovering and selecting interactors to not have interactions with this <see cref="InteractableObject"/> for one frame.
         /// </summary>

--- a/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
@@ -28,6 +28,15 @@ namespace VRBuilder.XRInteraction.Interactors
         public bool ShowHighlightObject { get; set; }
 
         [SerializeField]
+        [Tooltip("When enabled, snap using the interactable root instead of its configured Attach Transform.")]
+        private bool ignoreInteractableAttachTransform;
+
+        /// <summary>
+        /// Gets whether interactables use their root transform when snapping to this snap zone.
+        /// </summary>
+        public bool IgnoreInteractableAttachTransform => ignoreInteractableAttachTransform;
+
+        [SerializeField]
         private GameObject shownHighlightObject = null;
 
         /// <inheritdoc />

--- a/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
@@ -27,6 +27,7 @@ namespace VRBuilder.XRInteraction.Interactors
         /// </summary>
         public bool ShowHighlightObject { get; set; }
 
+        [Header("Snap Settings")]
         [SerializeField]
         [Tooltip("When enabled, snap using the interactable root instead of its configured Attach Transform.")]
         private bool ignoreInteractableAttachTransform;
@@ -36,6 +37,7 @@ namespace VRBuilder.XRInteraction.Interactors
         /// </summary>
         public bool IgnoreInteractableAttachTransform => ignoreInteractableAttachTransform;
 
+        [Header("Highlight Settings")]
         [SerializeField]
         private GameObject shownHighlightObject = null;
 

--- a/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
+++ b/Source/XRInteraction/Source/Runtime/Interactors/SnapZone.cs
@@ -27,9 +27,11 @@ namespace VRBuilder.XRInteraction.Interactors
         /// </summary>
         public bool ShowHighlightObject { get; set; }
 
+        [Header("VR Builder Snap Zone Settings")]
+
         [Header("Snap Settings")]
         [SerializeField]
-        [Tooltip("When enabled, snap using the interactable root instead of its configured Attach Transform.")]
+        [Tooltip("When enabled, always snap using the interactable root instead of the XRI default which is using a configured Attach Transform first.")]
         private bool ignoreInteractableAttachTransform;
 
         /// <summary>
@@ -65,7 +67,7 @@ namespace VRBuilder.XRInteraction.Interactors
         }
 
         /// <summary>
-        /// Shows the highlight 
+        /// Shows the highlight
         /// </summary>
         public bool ShowHighlightInEditor = true;
 
@@ -403,7 +405,7 @@ namespace VRBuilder.XRInteraction.Interactors
         }
 
         /// <summary>
-        /// This method is called by the interaction manager to update the interactor. 
+        /// This method is called by the interaction manager to update the interactor.
         /// Please see the interaction manager documentation for more details on update order.
         /// </summary>
         public override void ProcessInteractor(XRInteractionUpdateOrder.UpdatePhase updatePhase)


### PR DESCRIPTION
## Summary

- add **Ignore Interactable Attach Transform** checkbox to each SnapZone
- return interactable root transform when enabled
- preserve configured interactable Attach Transform behavior when disabled
- keep SnapZone Attach Transform/SnapPoint behavior unchanged
- Added Additional Headers 
<img width="551" height="303" alt="image" src="https://github.com/user-attachments/assets/e43e90b6-b14f-434d-b481-520d62e6bc23" />

Ticket: [Jira: VRB-3790](https://mindport.atlassian.net/browse/VRB-3790)
Context: Source of issues report https://mind-port.slack.com/archives/C04UTK83RC5/p1785161194963539

## Verification

- Unity AssetDatabase refresh and script compilation completed successfully
- entered and exited Play Mode successfully
- fresh Unity Error log after smoke check contained no entries
- `git diff --check` passed

## Tests

No extra automated tests added or run, per request.
Not tested or configured in a scene.

## User Tests
Manually Tested following case combinations with no issues:

Case | Interactable Attach Transform | Checkbox | Expected hover + final pose
-- | -- | -- | --
1 | Configured, offset from root | Off | Interactable Attach Transform aligns with SnapZone SnapPoint
2 | Configured, offset from root | On | Interactable root aligns with SnapZone SnapPoint
3 | None or Transform Zero | Off | Root aligns normally
4 | None / Transform Zero | On | Root aligns normally
5 | Configured, offset from root and Active Dynamic Attach | Off | Interactable root aligns with SnapZone SnapPoint
6 | Configured, offset from root and Active Dynamic Attach | On | Interactable root aligns with SnapZone SnapPoint

<img width="1914" height="1095" alt="image" src="https://github.com/user-attachments/assets/a02f5a07-5629-413e-8fa5-7f91cc28d977" />

