### PR TITLE
fix: align toggle condition semantics

### DIFF
--- a/Source/BasicInteraction/Runtime/Conditions/ToggleControlsCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/ToggleControlsCondition.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.Serialization;
+using UnityEngine;
 using VRBuilder.BasicInteraction.Properties;
 using VRBuilder.Core;
 using VRBuilder.Core.Attributes;
@@ -94,6 +95,12 @@ namespace VRBuilder.BasicInteraction.Conditions
         {
             protected override bool CheckIfCompleted()
             {
+                if (Data.ToggleControls.Values.Count() == 0)
+                {
+                    Debug.LogError($"No controls are set in {GetType().Name}. The condition will complete immediately.");
+                    return true;
+                }
+
                 if (Data.RequireRelease && Data.ToggleControls.Values.Any(control => control.IsInteracting))
                 {
                     return false;
@@ -118,7 +125,7 @@ namespace VRBuilder.BasicInteraction.Conditions
         {
         }
 
-        public ToggleControlsCondition(ISettableControlProperty<float> control, bool targetPosition, bool requireRelease = false) : this(ProcessReferenceUtils.GetUniqueIdFrom(control), targetPosition, requireRelease)
+        public ToggleControlsCondition(ISettableControlProperty<bool> control, bool targetPosition, bool requireRelease = false) : this(ProcessReferenceUtils.GetUniqueIdFrom(control), targetPosition, requireRelease)
         {
         }
 

--- a/Source/BasicInteraction/Runtime/Conditions/ToggleControlsCondition.cs
+++ b/Source/BasicInteraction/Runtime/Conditions/ToggleControlsCondition.cs
@@ -97,7 +97,7 @@ namespace VRBuilder.BasicInteraction.Conditions
             {
                 if (Data.ToggleControls.Values.Count() == 0)
                 {
-                    Debug.LogError($"No controls are set in {GetType().Name}. The condition will complete immediately.");
+                    Debug.LogWarning($"No controls are set in {GetType().Name}. The condition will complete immediately.");
                     return true;
                 }
 


### PR DESCRIPTION
## Summary
- Change the toggle-condition convenience constructor to accept the boolean control contract required by `ToggleControlsCondition<TProperty>`.
- Detect empty control references before evaluating any/all semantics.
- Log the same configuration error and complete immediately for both modes, matching Linear and Momentary control conditions.

## Why
`Enumerable.All` returns true for an empty collection while `Enumerable.Any` returns false. Without an explicit empty check, equivalent invalid configurations completed or stalled solely based on `SetAllControls`. The constructor's float control type was an unrelated copy/paste error.

Fixes [VRB-3795](https://mindport.atlassian.net/browse/VRB-3795).

Identified in [VR-Builder-Tests#22](https://github.com/MindPort-GmbH/VR-Builder-Tests/pull/22) and confirmed in [review comment #5180372558](https://github.com/MindPort-GmbH/VR-Builder-Tests/pull/22#issuecomment-5180372558).

## Impact
Boolean toggle properties can use the convenience constructor directly. Empty toggle references now behave consistently and report the invalid configuration instead of potentially waiting forever.

## Verification
- `ToggleControlsConditionTests`: 4 passed, 0 failed.
- Regression tests committed to VR-Builder-Tests as `3cb97de`.
- `git diff --check` passed in Core and Tests.

## Implementation Remarks
The empty-reference policy follows the existing Linear and Momentary condition behavior: log an error and complete immediately.

[VRB-3795]: https://mindport.atlassian.net/browse/VRB-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ